### PR TITLE
Feature: Automatic docker container build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,48 @@
+name: Docker
+
+on:
+  workflow_call:
+    inputs:
+      upload-tag:
+        type: string
+        default: "nightly"
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Login to Docker Hub
+        # if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,9 +29,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Tools
         run: |
-          curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 && mv tailwindcss-linux-x64 tailwindcss && chmod +x tailwindcss
-          cd frontend && npm install && npm install rollup --global && cd ..
-          ./tailwindcss
+          curl -o tailwindcss -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 && chmod +x tailwindcss
       - name: Setup rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,76 @@
-FROM archlinux:latest
-
-# Install
-RUN pacman -Suy --needed --noconfirm sudo curl base-devel git npm python
-RUN pacman -S --noconfirm task timew
-RUN useradd -m -G wheel builder && passwd -d builder
-RUN echo 'builder ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
-RUN chown -R builder:builder /home/builder && chmod -R 775 /home/builder
-RUN npm install --global rollup
-RUN mkdir -p /usr/share/doc/task/rc/
-USER builder
-ENV HOME=/home/builder
-WORKDIR /home/builder
-# Rustup
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh \
+FROM archlinux:latest AS rustbase
+RUN pacman -Suy --needed --noconfirm curl base-devel npm
+RUN mkdir /app \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh \
     && chmod +x rustup.sh \
     && ./rustup.sh -y --default-toolchain nightly \
-    && source $HOME/.cargo/env
+    # Tailwind
+    && cd /app && curl -o /app/tailwindcss -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 \
+    && chmod +x /app/tailwindcss
 
-RUN mkdir $HOME/app
-# Tailwind
-RUN cd $HOME/app && curl -o $HOME/app/tailwindcss -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 \
-    && chmod +x $HOME/app/tailwindcss
+FROM rustbase AS buildapp
+# Copy files
+COPY ./Cargo.toml /app/Cargo.toml
+COPY ./frontend /app/frontend
+COPY ./src /app/src
+COPY ./build.rs /app/
+RUN cd /app \
+    && source $HOME/.cargo/env \
+    && cargo build --release
+
+FROM archlinux:latest
+ARG TASK_ADDON_BUGWARRIOR="false"
+ARG TASK_ADDON_BUGWARRIOR_FEATURES=""
+
+# Install
+RUN echo "NoExtract = !usr/share/doc/timew/*" >> /etc/pacman.conf \
+ && echo "NoExtract = !usr/share/doc/task/*" >> /etc/pacman.conf \
+ && pacman -Suy --needed --noconfirm git python \
+ && pacman -S --noconfirm task timew \
+ && pacman -S --noconfirm python-pip \
+ && useradd -m -d /app task && passwd -d task \
+ && chown -R task:task /app && chmod -R 775 /app \
+ && mkdir -p /app/bin \
+ && mkdir -p /app/taskdata \
+ && mkdir -p /app/.task/hooks \
+ && mkdir -p /app/.timewarrior/data/ \
+ && cp /usr/share/doc/timew/ext/on-modify.timewarrior /app/.task/hooks/on-modify.timewarrior \
+ && ( [[ $TASK_ADDON_BUGWARRIOR != "true" ]] || python3 -m pip install --break-system-packages bugwarrior[$TASK_ADDON_BUGWARRIOR_FEATURES]@git+https://github.com/GothenburgBitFactory/bugwarrior.git ) \
+ # cleanup
+ && pacman --noconfirm -R git python-pip \ 
+ && echo "delete orphaned" \
+ && pacman --noconfirm -Qdtq | pacman --noconfirm -Rs - \
+ && echo "clear cache" \
+ && pacman --noconfirm -Sc \
+ && echo "clean folders" \
+ && rm -Rf /var/cache  \
+ && rm -Rf /var/log \
+ && rm -Rf /var/db \
+ && rm -Rf /var/lib \
+ && rm -Rf /usr/include \
+ && rm -Rf /run
+
+ENV HOME=/app
+WORKDIR /app
 
 # Copy files
-COPY ./frontend $HOME/app/frontend
-COPY ./src $HOME/app/src
-COPY ./build.rs $HOME/app/
-COPY ./Cargo.toml $HOME/app/Cargo.toml
-COPY ./docker/start.sh $HOME/start.sh
-RUN sudo chown -R $(whoami) $HOME/app
-RUN cd $HOME/app/frontend && npm install && cd ..
-RUN cd $HOME/app && source $HOME/.cargo/env &&cargo build --release
+COPY docker/start.sh /app/bin/start.sh
+COPY --from=buildapp /app/dist /app/bin/dist
+COPY --from=buildapp /app/target/release/taskwarrior-web /app/bin/taskwarrior-web
+
+RUN chown -R task /app \
+    && chmod +x /app/bin/start.sh
+
+USER task
 
 EXPOSE 3000
 
 # Taskwarrior data volume
-VOLUME [ "/usr/share/doc/task/rc" ]
+VOLUME /app/.task/
+VOLUME /app/.timewarrior/
 
-ENV TASKRC="$HOME/.taskrc"
-ENV TASKDATA="$HOME/.task"
+ENV TASKRC="/app/.taskrc"
+ENV TASKDATA="/app/taskdata"
+WORKDIR /app
 
-RUN sudo chmod +x $HOME/start.sh
-
-CMD ["/home/builder/start.sh"]
+ENTRYPOINT ["/app/bin/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ USER task
 EXPOSE 3000
 
 # Taskwarrior data volume
-VOLUME /app/.task/
+VOLUME /app/taskdata/
 VOLUME /app/.timewarrior/
 
 ENV TASKRC="/app/.taskrc"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # NEW!
 
-- Updated to tailwindcss 4 and using daisyui for UI components. 
+- Updated to tailwindcss 4 and using daisyui for UI components.
 - Cleaned-up code a bit to make it easier to manage
 
-Please report any bugs, contributions are welcome. 
+Please report any bugs, contributions are welcome.
 
 # What is this?
 
@@ -14,14 +14,16 @@ Font in the screenshot is [Maple Mono NF](https://github.com/subframe7536/maple-
 
 ## Stack
 
-* Rust [nightly, will fail to build on stable]
-* axum
-* tera
-* TailwindCSS
-* HTMX
-* hotkeys
-* rollup
-* Task Warrior (obviously :) )
+- [Rust](https://www.rust-lang.org/) [nightly, will fail to build on stable]
+- [axum](https://github.com/tokio-rs/axum)
+- [tera](https://github.com/Keats/tera)
+- [TailwindCSS](https://tailwindcss.com/)
+- [daisyUI](https://daisyui.com/)
+- HTMX
+- hotkeys
+- [rollup](https://rollupjs.org/)
+- [Taskwarrior](https://taskwarrior.org/) (obviously :))
+- [Timewarrior](https://timewarrior.net)
 
 Still work in progress. But in the current stage it is pretty usable. You can see the list at the bottom, for what I intend to add, and what's been done.
 
@@ -36,55 +38,84 @@ Latest release binaries are now available. Check the release tags on the sidebar
 Docker image is provided. A lot of thanks go to [DCsunset](https://github.com/DCsunset/taskwarrior-webui)
 and [RustDesk](https://github.com/rustdesk/rustdesk/)
 
-```shell 
+```shell
 docker build -t taskwarrior-web-rs . \
-&& docker run -d -p 3000:3000 \
--v ~/.task/:/home/builder/.task \
--v ~/.taskrc:/home/builder/.taskrc \
--v /usr/share/doc/task/rc/:/usr/share/doc/task/rc/:ro \
---name taskwarrior-web-rs taskwarrior-web-rs 
+&& docker run --init -d -p 3000:3000 \
+-v ~/.task/:/app/taskdata/ \
+-v ~/.taskrc:/app/.taskrc \
+-v ~/.timewarrior/:/app/.timewarrior/ \
+--name taskwarrior-web-rs taskwarrior-web-rs
+```
+
+As a service, every push to the `main` branch of this repository will provide automatic a docker image and can be pulled via
+
+```shell
+docker pull ghcr.io/tmahmood/taskwarrior-web:main
 ```
 
 That should do it.
+
+## Volumes
+
+The docker shares following directories as volumes to store data:
+
+| Volume path       | Purpose                                        |
+| ----------------- | ---------------------------------------------- |
+| /app/taskdata     | Stores task data (mostly taskchampion.sqlite3) |
+| /app/.timewarrior | Stores timewarrior data                        |
+
+It is recommend to specify the corresponding volume in order to persist the data.
+
+## Ports
+
+`taskwarrior-web` is internally listening on following ports `3000`:
+
+| Port | Protocol | Purpose                          |
+| ---- | -------- | -------------------------------- |
+| 3000 | tcp      | Main webserver to serve the page |
+
+## Environment variables
+
+In order to configure the environment variables and contexts for `timewarrior-web`, docker environments can be specified:
+
+| Docker environment               | Internal Variable       |
+| -------------------------------- | ----------------------- |
+| TASK_WEB_TWK_SERVER_PORT         | TWK_SERVER_PORT         |
+| TASK_WEB_DISPLAY_TIME_OF_THE_DAY | DISPLAY_TIME_OF_THE_DAY |
+| TASK_WEB_TWK_USE_FONT            | TWK_USE_FONT            |
+
+## Hooks
 
 NOTE: If you have any hooks
 (eg. Starting time tracking using time-warrior when we start a task,
 you'll need to install the required application in in the docker, also the config files)
 
+By default, the `timewarrior` on-modify hook is installed.
+
 # Manual Installation
+
 ## Requirements
 
-* rust nightly
-* npm
-* rollup
-* tailwindcss-cli
+- rust nightly
+- npm
+- tailwindcss-cli
 
 ### Installing rust nightly
 
 Should be installable through `rustup`
 https://rustup.rs/
 
-### Installing tailwindcss-cli and rollup
+### Installing tailwindcss-cli
 
 ```shell
-curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64
-mv tailwindcss-linux-x64 tailwindcss
+curl -o tailwindcss -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64
 chmod +x tailwindcss
-```
-
-### Install rollup
-
-```
-npm install rollup --global 
 ```
 
 ### Building and Running
 
 1. Clone the latest version from GitHub.
-2. `cd frontend`
-3. `npm install`
-4. `cd ..`
-5. `cargo run --release`
+2. `cargo run --release`
 
 That should be it! Now you have the server running at `localhost:3000` accessible by your browser.
 
@@ -107,11 +138,11 @@ It's because, `tailwindcss-cli` is missing
 By default, the program will use 3000 as port,
 you can customize through `.env` file or enviornment variable, check `env.example`
 
-variable name: `TWK_SERVER_PORT` 
+variable name: `TWK_SERVER_PORT`
 
 ### Displaying `time of the day` widget
 
-By default the "time of the day" widget is not visible, to display it put 
+By default the "time of the day" widget is not visible, to display it put
 
 `DISPLAY_TIME_OF_THE_DAY=1`
 
@@ -127,16 +158,14 @@ Add the following to change default font:
 
 `TWK_USE_FONT='Maple Mono'`
 
-
 # Using the app
 
 You can use Mouse or Keyboard to navigate.
 
 ![Top bar](./screenshots/top_bars.png)
 
-* All the keyboard mnemonics are underlined.
-* The `Cmd Bar` needs to be focused (`Ctrl + Shift + K`) for the keyboard shortcuts to work
-
+- All the keyboard mnemonics are underlined.
+- The `Cmd Bar` needs to be focused (`Ctrl + Shift + K`) for the keyboard shortcuts to work
 
 ## Project and Tag selection
 
@@ -187,8 +216,8 @@ This will bring up undo confirmation dialog
 This is a work in progress application, many things will not work,
 there will be errors, as no checks, and there may not be any error messages in case of error.
 
-
 ## Planned
+
 - [ ] Better configuration
 - [ ] Usability improvements on a long task list
   - [x] Hiding empty columns
@@ -211,10 +240,9 @@ there will be errors, as no checks, and there may not be any error messages in c
 - [ ] Searching by tag name
 
 ## Issues
+
 - [ ] Not able to select and copy tags, maybe add a copy button
 - [ ] Keyboard shortcut applied when there is a shortcut key and I use a mnemonic
 - [x] When marking task as done stop if active
-
-
 
 ![Change Log](CHANGELOG.md)

--- a/build.rs
+++ b/build.rs
@@ -1,20 +1,40 @@
-use std::process::Command;
+use std::{fs, process::Command};
 
 fn main() {
-    println!("cargo:rerun-if-changed=frontend/");
-    if let Err(_e) = Command::new("./tailwindcss")
-        .args(["-i", "frontend/css/style.css", "-o", "dist/style.css"])
-        .status()
-    {
-        panic!("Failed to process css")
+    let tailwindcss_bin = fs::canonicalize("./").expect("Cannot determine absolute path to current directory");
+    let tailwindcss_bin = tailwindcss_bin.join("tailwindcss");
+    if !tailwindcss_bin.exists() {
+        panic!("Cannot find tailwindcss binary in {}", tailwindcss_bin.to_string_lossy())
     }
-    if !Command::new("rollup")
-        .args(["-c", "frontend/rollup.config.js"])
+
+    println!("cargo:rerun-if-changed=frontend/");
+    println!("Install npm dependencies");
+    if !Command::new("npm")
+        .current_dir("frontend")
+        .args(["install"])
+        .status()
+        .unwrap()
+        .success()
+    {
+        panic!("Could not install dependencies")
+    }
+
+    if !Command::new(tailwindcss_bin)
+        .args(["-i", "frontend/css/style.css", "-o", "dist/style.css"])
         .status()
         .unwrap()
         .success()
     {
         panic!("Failed to process css")
+    }
+
+    if !Command::new("frontend/node_modules/rollup/dist/bin/rollup")
+        .args(["-c", "frontend/rollup.config.js"])
+        .status()
+        .unwrap()
+        .success()
+    {
+        panic!("Failed to process js")
     }
     // adding templates
     if !Command::new("cp")

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,7 +1,21 @@
 #!/bin/bash
 
 set -e
+DOTENV_FILE="$HOME/.env"
+# create empty dot env file
+echo "" > $DOTENV_FILE
 
-cd $HOME/app/
-source $HOME/.cargo/env
-cargo run --release
+while IFS='=' read -r -d '' n v; do
+    if [[ $n == TASK_WEB_* ]]; then
+        echo "${n/TASK_WEB_/}=\"$v\"" >> $DOTENV_FILE
+    fi
+done < <(env -0)
+
+# check if taskrc exists.
+if [[ ! -f "$TASKRC" ]]; then
+    echo "yes" | task || true
+fi
+
+cd $HOME/bin
+exec ./taskwarrior-web
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,13 +10,14 @@
     "@rollup/plugin-typescript": "^12.1.2",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
-    "tailwindcss": "^4.0.9",
-    "tslib": "^2.8.1",
-    "typescript": "^5.7.3",
     "daisyui": "^5.0.0-beta.8",
     "hotkeys-js": "^3.13.9",
     "htmx.org": "2.0.0-beta4",
     "hyperscript.org": "^0.9.14",
-    "postcss": "^8.5.3"
+    "postcss": "^8.5.3",
+    "tailwindcss": "^4.0.9",
+    "tslib": "^2.8.1",
+    "typescript": "^5.7.3",
+    "rollup": "^4.38.0"
   }
 }


### PR DESCRIPTION
With this commit an automatic github docker build process is established.

The docker image creation process was redefined and clear volumes were specified in order to store task and timewarrior data.

Furthermore variable declaration routines were defined in order to automatic populate the `.env` file for the use of `dotenvy` routine in `src/main.rs`.

The docker image is created in addition to the binary release on `main` branch. On every pull request, the docker image is created as well to ensure, that the docker image is still be able to build, but it is not uploaded to the package repository of `github`.

Refers: tmahmood/taskwarrior-web#4