### PR TITLE
Feature: Rust Nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Currently, the whole system must be switched to Rust nightly in order to just jump in and compile with `cargo build`.

This commit introduces the `rust-toolchain.toml`, which declares, that the project must be compiled with the `nightly` compiler.

In this case, it is automatically downloading the right toolchain. See:
```shell
$ ~/d/e/t/web-github (feature/nightly)> env TASKDATA=~/.task cargo run
info: syncing channel updates for 'nightly-x86_64-unknown-linux-gnu'
info: latest update on 2025-03-30, rust version 1.88.0-nightly (1799887bb 2025-03-29)
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'rust-docs'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'rust-docs'
info: installing component 'rust-std'
info: installing component 'rustc'
info: installing component 'rustfmt'
   Compiling taskwarrior-web v2.0.0 (~/d/e/t/web-github)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.93s
     Running `target/debug/taskwarrior-web`
(...)
```

If you uninstall in the workspace you even get a warning note:
```shell
~/d/e/t/web-github (feature/nightly) [101]> rustup toolchain uninstall nightly
warn: removing the active toolchain; a toolchain override will be required for running Rust tools
info: uninstalling toolchain 'nightly-x86_64-unknown-linux-gnu'
info: toolchain 'nightly-x86_64-unknown-linux-gnu' uninstalled
```