### PR TITLE
Feature: Light mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Font in the screenshot is [Maple Mono NF](https://github.com/subframe7536/maple-
 - [tera](https://github.com/Keats/tera)
 - [TailwindCSS](https://tailwindcss.com/)
 - [daisyUI](https://daisyui.com/)
-- HTMX
-- hotkeys
+- [HTMX](https://htmx.org)
+- [hotkeys](https://github.com/jaywcjlove/hotkeys-js)
 - [rollup](https://rollupjs.org/)
 - [Taskwarrior](https://taskwarrior.org/) (obviously :))
 - [Timewarrior](https://timewarrior.net)
@@ -68,7 +68,7 @@ It is recommend to specify the corresponding volume in order to persist the data
 
 ## Ports
 
-`taskwarrior-web` is internally listening on following ports `3000`:
+`taskwarrior-web` is by default internally listening on port `3000`:
 
 | Port | Protocol | Purpose                          |
 | ---- | -------- | -------------------------------- |
@@ -78,11 +78,12 @@ It is recommend to specify the corresponding volume in order to persist the data
 
 In order to configure the environment variables and contexts for `timewarrior-web`, docker environments can be specified:
 
-| Docker environment               | Internal Variable       |
-| -------------------------------- | ----------------------- |
-| TASK_WEB_TWK_SERVER_PORT         | TWK_SERVER_PORT         |
-| TASK_WEB_DISPLAY_TIME_OF_THE_DAY | DISPLAY_TIME_OF_THE_DAY |
-| TASK_WEB_TWK_USE_FONT            | TWK_USE_FONT            |
+| Docker environment               | Shell environment       | Purpose 
+| -------------------------------- | ----------------------- | ---------------------------------------------------------|
+| TASK_WEB_TWK_SERVER_PORT         | TWK_SERVER_PORT         | Specifies the server port (see "Ports")                  |
+| TASK_WEB_DISPLAY_TIME_OF_THE_DAY | DISPLAY_TIME_OF_THE_DAY | Displays a time of the day widget in case of value `1`   |
+| TASK_WEB_TWK_USE_FONT            | TWK_USE_FONT            | Font to be used. If not, browsers default fonts are used |
+| TASK_WEB_TWK_THEME               | TWK_THEME               | Defines the theme to be used (see "Themes")              | 
 
 ## Hooks
 
@@ -133,6 +134,8 @@ if you are receiving the following error in step 5
 
 It's because, `tailwindcss-cli` is missing
 
+## Customizing
+
 ### Customizing the port
 
 By default, the program will use 3000 as port,
@@ -157,6 +160,19 @@ And the font can be set using env variable.
 Add the following to change default font:
 
 `TWK_USE_FONT='Maple Mono'`
+
+### Themes
+
+By default, `taskwarrior-web` provides two themes:
+
+1. taskwarrior-dark (intended for dark mode)
+2. taskwarrior-light (intended for light mode)
+
+`taskwarrior-web` decides automatically based on the operating system and [browser preferences](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) whether the light or the dark theme should be shown.
+
+If a specific theme should be set fixed, the theme can be set as following in the environment:
+
+`TWK_THEME=taskwarrior-dark` (for dark-mode)
 
 # Using the app
 
@@ -210,6 +226,18 @@ Keyboard shortcut is `u`
 
 This will bring up undo confirmation dialog
 ![Undo](./screenshots/undo.png)
+
+## Switch theme
+
+It is possible to switch the theme, which is saved in local storage too.
+
+For this following three symbols are used (left of the command bar):
+
+| Symbol | Purpose                               |
+|--------|---------------------------------------|
+|   ⚹    | Auto Mode or forced mode from server |  
+|   ☽    | Dark mode                            |
+|   🌣    | Light mode                           |
 
 # WIP warning
 

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1,50 +1,85 @@
 @import "tailwindcss";
 @config "../tailwind.config.js";
-@plugin "daisyui";
-
-
-
-
-
-@plugin "daisyui/theme" {
-    name: "task-warrior";
-    default: false;
-    prefersdark: false;
-    color-scheme: "dark";
-    --color-base-100: oklch(21% 0.006 56.043);
-    --color-base-200: oklch(14% 0.004 49.25);
-    --color-base-300: oklch(0% 0 0);
-    --color-base-content: oklch(84.955% 0 0);
-    --color-primary: oklch(50% 0.134 242.749);
-    --color-primary-content: oklch(19.693% 0.004 196.779);
-    --color-secondary: oklch(43% 0 0);
-    --color-secondary-content: oklch(89.196% 0.049 305.03);
-    --color-accent: oklch(55% 0.027 264.364);
-    --color-accent-content: oklch(0% 0 0);
-    --color-neutral: oklch(37% 0.034 259.733);
-    --color-neutral-content: oklch(84.874% 0.009 65.681);
-    --color-info: oklch(54.615% 0.215 262.88);
-    --color-info-content: oklch(90.923% 0.043 262.88);
-    --color-success: oklch(62.705% 0.169 149.213);
-    --color-success-content: oklch(12.541% 0.033 149.213);
-    --color-warning: oklch(66.584% 0.157 58.318);
-    --color-warning-content: oklch(13.316% 0.031 58.318);
-    --color-error: oklch(65.72% 0.199 27.33);
-    --color-error-content: oklch(13.144% 0.039 27.33);
-    --radius-selector: 0.25rem;
-    --radius-field: 0.25rem;
-    --radius-box: 0.25rem;
-    --size-selector: 0.25rem;
-    --size-field: 0.25rem;
-    --border: 1px;
-    --depth: 1;
-    --noise: 0;
+@plugin "daisyui" {
+  themes: task-warrior-light, task-warrior-dark;
+  root: ":root";
+  darktheme: "task-warrior-dark";
+  logs: false;
 }
 
+@plugin "daisyui/theme" {
+  name: "task-warrior-dark";
+  default: false;
+  prefersdark: true;
+  color-scheme: "dark";
+  --color-base-100: oklch(21% 0.006 56.043);
+  --color-base-200: oklch(14% 0.004 49.25);
+  --color-base-300: oklch(0% 0 0);
+  --color-base-content: oklch(84.955% 0 0);
+  --color-primary: oklch(50% 0.134 242.749);
+  --color-primary-content: oklch(19.693% 0.004 196.779);
+  --color-secondary: oklch(43% 0 0);
+  --color-secondary-content: oklch(89.196% 0.049 305.03);
+  --color-accent: oklch(55% 0.027 264.364);
+  --color-accent-content: oklch(0% 0 0);
+  --color-neutral: oklch(37% 0.034 259.733);
+  --color-neutral-content: oklch(84.874% 0.009 65.681);
+  --color-info: oklch(54.615% 0.215 262.88);
+  --color-info-content: oklch(90.923% 0.043 262.88);
+  --color-success: oklch(62.705% 0.169 149.213);
+  --color-success-content: oklch(12.541% 0.033 149.213);
+  --color-warning: oklch(66.584% 0.157 58.318);
+  --color-warning-content: oklch(13.316% 0.031 58.318);
+  --color-error: oklch(65.72% 0.199 27.33);
+  --color-error-content: oklch(13.144% 0.039 27.33);
+  --radius-selector: 0.25rem;
+  --radius-field: 0.25rem;
+  --radius-box: 0.25rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 1px;
+  --depth: 1;
+  --noise: 0;
+}
+
+@plugin "daisyui/theme" {
+  name: "task-warrior-light";
+  default: true;
+  prefersdark: false;
+  color-scheme: "light";
+  --color-base-100: oklch(100% 0 0);
+  --color-base-200: oklch(98% 0 0);
+  --color-base-300: oklch(95% 0 0);
+  --color-base-content: oklch(21% 0.006 285.885);
+  --color-primary: oklch(45% 0.24 277.023);
+  --color-primary-content: oklch(93% 0.034 272.788);
+  --color-secondary: oklch(65% 0.241 354.308);
+  --color-secondary-content: oklch(94% 0.028 342.258);
+  --color-accent: oklch(77% 0.152 181.912);
+  --color-accent-content: oklch(38% 0.063 188.416);
+  --color-neutral: oklch(14% 0.005 285.823);
+  --color-neutral-content: oklch(92% 0.004 286.32);
+  --color-info: oklch(74% 0.16 232.661);
+  --color-info-content: oklch(29% 0.066 243.157);
+  --color-success: oklch(76% 0.177 163.223);
+  --color-success-content: oklch(37% 0.077 168.94);
+  --color-warning: oklch(82% 0.189 84.429);
+  --color-warning-content: oklch(41% 0.112 45.904);
+  --color-error: oklch(71% 0.194 13.428);
+  --color-error-content: oklch(27% 0.105 12.094);
+  --radius-selector: 0.5rem;
+  --radius-field: 0.25rem;
+  --radius-box: 0.5rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 1px;
+  --depth: 1;
+  --noise: 0;
+}
 
 @plugin "@tailwindcss/typography";
 @plugin "@tailwindcss/forms";
 
 .shortcut_key {
-    @apply px-1 mx-0.5 space-x-0 opacity-50 text-white bg-base-100 rounded-sm;
+  @apply px-1 mx-0.5 space-x-0 opacity-50 text-base-content bg-base-100 rounded-sm;
 }

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1,14 +1,14 @@
 @import "tailwindcss";
 @config "../tailwind.config.js";
 @plugin "daisyui" {
-  themes: task-warrior-light, task-warrior-dark;
+  themes: taskwarrior-light, taskwarrior-dark;
   root: ":root";
-  darktheme: "task-warrior-dark";
+  darktheme: "taskwarrior-dark";
   logs: false;
 }
 
 @plugin "daisyui/theme" {
-  name: "task-warrior-dark";
+  name: "taskwarrior-dark";
   default: false;
   prefersdark: true;
   color-scheme: "dark";
@@ -43,7 +43,7 @@
 }
 
 @plugin "daisyui/theme" {
-  name: "task-warrior-light";
+  name: "taskwarrior-light";
   default: true;
   prefersdark: false;
   color-scheme: "light";

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,7 @@ import 'htmx.org';
 import 'hyperscript.org';
 import * as _hyperscript from "hyperscript.org";
 import hotkeys from "hotkeys-js";
+import * as theme from "./theme.ts";
 
 _hyperscript.browserInit();
 
@@ -54,7 +55,7 @@ hotkeys('t', function (event, handler) {
 
 hotkeys('ctrl+shift+K', function (event, handler) {
     // Prevent the default refresh event under WINDOWS system
-    event.preventDefault()
+    event.preventDefault();
     focusTextInput(event);
     return false;
 });
@@ -70,13 +71,21 @@ window['toggleTagPanel'] = () => {
 
 document.addEventListener('click', function (event) {
     let element = document.getElementsByTagName('html')[0];
-    if (event.target !== element) {
-        return;
+    switch(event.target) {
+        case element:
+            focusTextInput(event);
+            break;
+        case document.getElementById('theme-switcher'):
+            event.preventDefault();
+            theme.switchTheme();
+            break;
     }
-    focusTextInput(event);
+    return;
 })
 
 document.addEventListener("DOMContentLoaded", function () {
+    theme.init();
+
     let n = setInterval(
         () => {
             let whichOne = 0;
@@ -130,3 +139,4 @@ document.addEventListener("DOMContentLoaded", function () {
         }, 1000
     )
 });
+

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,0 +1,71 @@
+export const SUPPORTED_THEMES = ["taskwarrior-dark", "taskwarrior-light"];
+export const THEME_ICONS = ["⚹", "☽", "🌣"];
+const STORAGE_THEME_KEY = "TWK_THEME";
+const DOM_THEME_KEY = "data-theme";
+
+function getThemeStorage() : string | null {
+    const theme = localStorage.getItem(STORAGE_THEME_KEY);
+    return theme;
+}
+
+function getThemeDom() : string | null {
+    const theme = document.getElementsByTagName('html')[0].getAttribute(DOM_THEME_KEY);
+    return theme;
+}
+
+function getTheme() : string | null {
+    const themeStorage = getThemeStorage();
+    const themeDom = getThemeDom();
+
+    return themeDom === null ? themeStorage : themeDom;
+}
+
+function setTheme(theme: string | null) : boolean {
+    if (theme === null) {
+        localStorage.removeItem(STORAGE_THEME_KEY);
+        document.getElementsByTagName('html')[0].removeAttribute(DOM_THEME_KEY);
+    } else {
+        localStorage.setItem(STORAGE_THEME_KEY, theme);
+        document.getElementsByTagName('html')[0].setAttribute(DOM_THEME_KEY, theme);
+    }
+
+    let themeIndex = -1;
+    if (theme != null) {
+        themeIndex = SUPPORTED_THEMES.indexOf(theme);
+    }
+    const iconIndex = themeIndex + 1;
+    document.getElementById('theme-switcher')?.innerText = THEME_ICONS.at(iconIndex);
+
+    return true;
+}
+
+export function switchTheme() {
+    const currentTheme = getTheme();
+    let themeIndex = -1;
+    if (currentTheme != null) {
+        themeIndex = SUPPORTED_THEMES.indexOf(currentTheme);
+    }
+    themeIndex = themeIndex + 1;
+    if (themeIndex >= SUPPORTED_THEMES.length) {
+        themeIndex = -1;
+    }
+
+    if (themeIndex >= 0) {
+        setTheme(SUPPORTED_THEMES.at(themeIndex)!);
+    } else {
+        setTheme(null);
+    }
+}
+
+export function init() {
+    // Ensure, that the icon is set correctly.
+    const themeDom = getThemeDom();
+    setTheme(themeDom!);
+    
+    // Check if there is anything different.
+    // Local storage is overriding DOM on initial read.
+    const theme = getThemeStorage();
+    if (theme != null) {
+        setTheme(theme!);
+    }
+}

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" {% if DEFAULT_THEME %}data-theme="{{ DEFAULT_THEME }}" {% endif %}>
 <head>
     <link rel="stylesheet" href="/dist/style.css"/>
     <style>

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="task-warrior">
+<html lang="en">
 <head>
     <link rel="stylesheet" href="/dist/style.css"/>
     <style>

--- a/frontend/templates/left_action_bar.html
+++ b/frontend/templates/left_action_bar.html
@@ -1,4 +1,4 @@
-<div class="pl-2 pr-2 py-1.5 rounded-sm text-xs flex bg-base-100 gap-2" xmlns:hx-on="http://www.w3.org/1999/xhtml">
+<div class="pl-2 pr-2 py-1.5 rounded-sm text-xs flex bg-base-100 gap-2 items-center" xmlns:hx-on="http://www.w3.org/1999/xhtml">
     <div class="join" id="tag_search_bar">
         <button class="btn btn-neutral btn-xs join-item" id="tag-selection-toggle" onclick="window['toggleTagPanel']()">
             <span><span class="shortcut_key"
@@ -103,10 +103,14 @@
             <span><span class="shortcut_key">L</span></span>
         </button>
     </div>
+    <!-- Other options -->
+    <div>
+        <button class="btn btn-xs btn-ghost" id="theme-switcher">⚹</button>
+    </div>
     <!-- CMD BAR -->
     <div>
         <label class="" for="cmd-inp"></label>
         <input type="search" class="input input-xs input-neutral focus:border-base-100 grow input-ghost border-base-200" placeholder="Cmd Bar, Ctrl+Shift+k" id="cmd-inp"
-               autofocus/>
+               autofocus value="" autocomplete="off" />
     </div>
 </div>

--- a/frontend/templates/task_add.html
+++ b/frontend/templates/task_add.html
@@ -1,6 +1,6 @@
 {% set bg_color = "bg-neutral-800" %}
 <div class="modal-box">
-    <h2 class="text-lg  font-bold text-neutral-50">Adding new task</h2>
+    <h2 class="text-lg  font-bold text-neutral-content-50">Adding new task</h2>
 
     <form class="mt-2 text-sm" id="task_add_form"
 

--- a/frontend/templates/task_details.html
+++ b/frontend/templates/task_details.html
@@ -1,6 +1,6 @@
 {% import "desc.html" as desc %}
 <div class="modal-box">
-    <h2 class="text-lg font-bold text-neutral-200">Task Details</h2>
+    <h2 class="text-lg font-bold text-neutral-content-200">Task Details</h2>
     <div class="join mb-3">
         <button class="btn btn-xs btn-warning join-item"
                 id="tag-btn-back-details"

--- a/frontend/templates/tasks.html
+++ b/frontend/templates/tasks.html
@@ -60,7 +60,7 @@
 
         <div class="grid grid-cols-1">
             <div id="tags_map_drawer" class="pt-4 hidden mb-2">
-                <div class="flex flex-wrap gap-2 p-4 bg-accent-content">
+                <div class="flex flex-wrap gap-2 p-4 bg-base-300">
                     <div class="join">
                         <button
                                 id="tag-btn-back"
@@ -91,7 +91,7 @@
                         <div class="flex gap-2">
                             <button id="{{shortcut}}"
                                     {% if tag is starting_with('+') %}
-                                    class="btn btn-xs btn-accent shrink"
+                                    class="btn btn-xs btn-accent-content shrink"
                                     hx-get="tasks?query={{ tag | replace(from='+', to='%2B') }}"
                                     {% elif tag is starting_with('@') %}
                                     class="btn btn-xs btn-info shrink"

--- a/frontend/templates/tasks.html
+++ b/frontend/templates/tasks.html
@@ -45,7 +45,7 @@
         <!-- // -->
     </div>
 
-    <div class="relative overflow-x-auto shadow-md sm:rounded-b-lg overflow-y-auto mt-16 pt-0 pb-2 mb-5">
+    <div class="relative overflow-x-auto shadow-md sm:rounded-b-lg overflow-y-auto mt-20 pt-0 pb-2 mb-5">
 
         {% if display_time_of_the_day == 1 %}
         <div class="justify-start items-center h-4" id="time_of_the_day">
@@ -113,7 +113,7 @@
             <div>
                 <ul class="list bg-base-100 rounded-box shadow-md text-sm">
                     {% for task in tasks %}
-                    <li class="list-row {% if task.start %} bg-green-700 {% endif %} p-2">
+                    <li class="list-row {% if task.start %} bg-green-700 text-green-200 {% endif %} p-2">
                         <div>
                             <input type="checkbox"
                                    class="checkbox checkbox-sm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,17 +2,18 @@
 #![feature(let_chains)]
 
 use std::collections::HashMap;
-use std::fmt;
 use std::str::FromStr;
+use std::{env, fmt};
 
+use crate::endpoints::tasks::task_query_builder::{TaskQuery, TaskReport};
+use crate::endpoints::tasks::{is_a_tag, is_tag_keyword};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use chrono::{DateTime, TimeDelta};
 use rand::distr::{Alphanumeric, SampleString};
 use serde::{de, Deserialize, Deserializer, Serialize};
-use tracing::{warn};
-use crate::endpoints::tasks::{is_a_tag, is_tag_keyword};
-use crate::endpoints::tasks::task_query_builder::{TaskQuery, TaskReport};
+use tera::Context;
+use tracing::warn;
 
 lazy_static::lazy_static! {
     pub static ref TEMPLATES: tera::Tera = {
@@ -39,6 +40,47 @@ lazy_static::lazy_static! {
         ]);
         tera
     };
+}
+
+#[derive(Clone, Debug)]
+pub struct AppState {
+    pub font: Option<String>,
+    pub fallback_family: String,
+    pub theme: Option<String>,
+    pub display_time_of_the_day: i32,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        let font = env::var("TWK_USE_FONT").map(|p| Some(p)).unwrap_or(None);
+        let theme = match env::var("TWK_THEME") {
+            Ok(p) if p.is_empty() => None,
+            Ok(p) => Some(p),
+            Err(_) => None,
+        };
+        let display_time_of_the_day = env::var("DISPLAY_TIME_OF_THE_DAY")
+            .unwrap_or("0".to_string())
+            .parse::<i32>()
+            .unwrap_or(0);
+
+        Self {
+            font: font,
+            fallback_family: "monospace".to_string(),
+            theme: theme,
+            display_time_of_the_day: display_time_of_the_day,
+        }
+    }
+}
+
+impl From<&AppState> for Context {
+    fn from(val: &AppState) -> Self {
+        let mut ctx = Context::new();
+        ctx.insert("USE_FONT", &val.font);
+        ctx.insert("FALLBACK_FAMILY", &val.fallback_family);
+        ctx.insert("DEFAULT_THEME", &val.theme);
+        ctx.insert("display_time_of_the_day", &val.display_time_of_the_day);
+        ctx
+    }
 }
 
 pub struct AppError(anyhow::Error);
@@ -71,9 +113,8 @@ pub enum Requests {
     Filtering {
         project: Option<String>,
         tags: Option<Vec<String>>,
-    }
+    },
 }
-
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone, Serialize)]
@@ -92,7 +133,10 @@ impl FlashMsg {
     }
 
     pub fn new(msg: &str, timeout: Option<u64>) -> Self {
-        Self { msg: msg.to_string(), timeout }
+        Self {
+            msg: msg.to_string(),
+            timeout,
+        }
     }
 }
 
@@ -145,7 +189,6 @@ impl TWGlobalState {
     }
 }
 
-
 pub fn task_query_merge_previous_params(state: &TWGlobalState) -> TaskQuery {
     if let Some(fv) = state.filter_value.clone() {
         let mut tq: TaskQuery = serde_json::from_str(&fv).unwrap();
@@ -165,7 +208,9 @@ pub fn task_query_previous_params(params: &TWGlobalState) -> TaskQuery {
 }
 
 pub fn from_task_to_task_update(params: &TWGlobalState) -> Option<TaskUpdateStatus> {
-    if let Some(uuid) = params.uuid.as_ref() && let Some(status) = params.status.as_ref() {
+    if let Some(uuid) = params.uuid.as_ref()
+        && let Some(status) = params.status.as_ref()
+    {
         return Some(TaskUpdateStatus {
             status: status.clone(),
             uuid: uuid.clone(),
@@ -195,7 +240,6 @@ pub struct TaskUpdateStatus {
     pub uuid: String,
 }
 
-
 /// Serde deserialization decorator to map empty Strings to None,
 pub fn empty_string_as_none<'de, D, T>(de: D) -> Result<Option<T>, D::Error>
 where
@@ -210,74 +254,95 @@ where
     }
 }
 
-
 fn remove_project_from_tag() -> impl tera::Function {
-    Box::new(move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
-        let mut pname = tera::from_value::<String>(
-            args.get("task").clone().unwrap().clone()
-        ).unwrap();
-        pname = pname.replace("project:", "").split(".").last().unwrap().to_string();
-        Ok(tera::to_value(pname).unwrap())
-    })
+    Box::new(
+        move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
+            let mut pname =
+                tera::from_value::<String>(args.get("task").clone().unwrap().clone()).unwrap();
+            pname = pname
+                .replace("project:", "")
+                .split(".")
+                .last()
+                .unwrap()
+                .to_string();
+            Ok(tera::to_value(pname).unwrap())
+        },
+    )
 }
 
 fn get_project_name_link() -> impl tera::Function {
-    Box::new(move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
-        let pname = tera::from_value::<String>(
-            args.get("full_name").clone().unwrap().clone()
-        ).unwrap();
-        let index = tera::from_value::<usize>(
-            args.get("index").clone().unwrap().clone()
-        ).unwrap();
-        let r: Vec<&str> = pname.split(".").take(index).collect();
-        Ok(tera::to_value(r.join(".")).unwrap())
-    })
+    Box::new(
+        move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
+            let pname =
+                tera::from_value::<String>(args.get("full_name").clone().unwrap().clone()).unwrap();
+            let index =
+                tera::from_value::<usize>(args.get("index").clone().unwrap().clone()).unwrap();
+            let r: Vec<&str> = pname.split(".").take(index).collect();
+            Ok(tera::to_value(r.join(".")).unwrap())
+        },
+    )
 }
 
 fn is_tag_keyword_tests() -> impl tera::Test {
-    Box::new(move |val: Option<&tera::Value>, _values: &[tera::Value]| -> tera::Result<bool>{
-        let v_str = val.as_ref().unwrap().to_string();
-        Ok(is_tag_keyword(&v_str))
-    })
+    Box::new(
+        move |val: Option<&tera::Value>, _values: &[tera::Value]| -> tera::Result<bool> {
+            let v_str = val.as_ref().unwrap().to_string();
+            Ok(is_tag_keyword(&v_str))
+        },
+    )
 }
 
 fn is_tag_tests() -> impl tera::Test {
-    Box::new(move |val: Option<&tera::Value>, _values: &[tera::Value]| -> tera::Result<bool>{
-        let v_str = val.as_ref().unwrap().to_string();
-        Ok(is_a_tag(&v_str))
-    })
+    Box::new(
+        move |val: Option<&tera::Value>, _values: &[tera::Value]| -> tera::Result<bool> {
+            let v_str = val.as_ref().unwrap().to_string();
+            Ok(is_a_tag(&v_str))
+        },
+    )
 }
 
 fn update_unique_tags() -> impl tera::Filter {
-    Box::new(move |value: &tera::Value, args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
-        let mut tags = tera::from_value::<Vec<String>>(value.clone())?;
-        let new_tag = tera::from_value::<String>(args.get("tag").clone().unwrap().clone())?;
-        tags.push(new_tag);
-        Ok(tera::to_value(tags)?)
-    })
+    Box::new(
+        move |value: &tera::Value,
+              args: &HashMap<String, tera::Value>|
+              -> tera::Result<tera::Value> {
+            let mut tags = tera::from_value::<Vec<String>>(value.clone())?;
+            let new_tag = tera::from_value::<String>(args.get("tag").clone().unwrap().clone())?;
+            tags.push(new_tag);
+            Ok(tera::to_value(tags)?)
+        },
+    )
 }
 
 fn obj() -> impl tera::Function {
-    Box::new(move |_args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
-        let hm: HashMap<String, String> = HashMap::new();
-        Ok(tera::to_value(hm)?)
-    })
+    Box::new(
+        move |_args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
+            let hm: HashMap<String, String> = HashMap::new();
+            Ok(tera::to_value(hm)?)
+        },
+    )
 }
 
 fn update_tag_bar_key_comb() -> impl tera::Filter {
-    Box::new(move |value: &tera::Value, args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
-        let mut tag_key_comb = tera::from_value::<HashMap<String, String>>(value.clone())?;
-        let tag = tera::from_value::<String>(args.get("tag").clone().unwrap().clone())?;
-        loop {
-            let string = Alphanumeric.sample_string(&mut rand::rng(), 2).to_lowercase();
-            if tag_key_comb.iter().find(|&(_k, v)| v == &string).is_some() {
-                continue;
+    Box::new(
+        move |value: &tera::Value,
+              args: &HashMap<String, tera::Value>|
+              -> tera::Result<tera::Value> {
+            let mut tag_key_comb = tera::from_value::<HashMap<String, String>>(value.clone())?;
+            let tag = tera::from_value::<String>(args.get("tag").clone().unwrap().clone())?;
+            loop {
+                let string = Alphanumeric
+                    .sample_string(&mut rand::rng(), 2)
+                    .to_lowercase();
+                if tag_key_comb.iter().find(|&(_k, v)| v == &string).is_some() {
+                    continue;
+                }
+                tag_key_comb.insert(tag, string);
+                break;
             }
-            tag_key_comb.insert(tag, string);
-            break;
-        }
-        Ok(tera::to_value(tag_key_comb)?)
-    })
+            Ok(tera::to_value(tag_key_comb)?)
+        },
+    )
 }
 
 pub struct DeltaNow {
@@ -288,50 +353,61 @@ pub struct DeltaNow {
 
 impl DeltaNow {
     pub fn new(time: &str) -> Self {
-        let time = chrono::prelude::NaiveDateTime::parse_from_str(time, "%Y%m%dT%H%M%SZ").unwrap().and_utc();
+        let time = chrono::prelude::NaiveDateTime::parse_from_str(time, "%Y%m%dT%H%M%SZ")
+            .unwrap()
+            .and_utc();
         let now = chrono::prelude::Utc::now();
         let delta = now - time;
         Self { now, delta, time }
     }
 }
 
-
 fn get_date_proper() -> impl tera::Function {
-    Box::new(move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
-        // we are working with utc time
-        let DeltaNow { now: _, delta, time: _time } = DeltaNow::new(args.get("date").unwrap().as_str().unwrap());
+    Box::new(
+        move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
+            // we are working with utc time
+            let DeltaNow {
+                now: _,
+                delta,
+                time: _time,
+            } = DeltaNow::new(args.get("date").unwrap().as_str().unwrap());
 
-        let num_weeks = delta.num_weeks();
-        let num_days = delta.num_days();
-        let num_hours = delta.num_hours();
-        let num_minutes = delta.num_minutes();
+            let num_weeks = delta.num_weeks();
+            let num_days = delta.num_days();
+            let num_hours = delta.num_hours();
+            let num_minutes = delta.num_minutes();
 
-        let in_future = args.get("in_future")
-            .cloned()
-            .unwrap_or(tera::Value::Bool(false))
-            .as_bool().unwrap();
+            let in_future = args
+                .get("in_future")
+                .cloned()
+                .unwrap_or(tera::Value::Bool(false))
+                .as_bool()
+                .unwrap();
 
-        let sign = if in_future { -1 } else { 1 };
+            let sign = if in_future { -1 } else { 1 };
 
-        let s = if num_weeks.abs() > 0 {
-            format!("{}w", sign * num_weeks)
-        } else if num_days.abs() > 0 {
-            format!("{}d", sign * num_days)
-        } else if num_hours.abs() > 0 {
-            format!("{}h", sign * num_hours)
-        } else {
-            format!("{}m", sign * num_minutes)
-        };
-        Ok(tera::to_value(s).unwrap())
-    })
+            let s = if num_weeks.abs() > 0 {
+                format!("{}w", sign * num_weeks)
+            } else if num_days.abs() > 0 {
+                format!("{}d", sign * num_days)
+            } else if num_hours.abs() > 0 {
+                format!("{}h", sign * num_hours)
+            } else {
+                format!("{}m", sign * num_minutes)
+            };
+            Ok(tera::to_value(s).unwrap())
+        },
+    )
 }
 
 fn get_date() -> impl tera::Function {
-    Box::new(move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
-        // we are working with utc time
-        let DeltaNow { time, .. } = DeltaNow::new(args.get("date").unwrap().as_str().unwrap());
-        Ok(tera::to_value(time.format("%Y-%b-%d %H:%m").to_string()).unwrap())
-    })
+    Box::new(
+        move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
+            // we are working with utc time
+            let DeltaNow { time, .. } = DeltaNow::new(args.get("date").unwrap().as_str().unwrap());
+            Ok(tera::to_value(time.format("%Y-%b-%d %H:%m").to_string()).unwrap())
+        },
+    )
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -362,18 +438,29 @@ impl NewTask {
 }
 
 fn get_timer() -> impl tera::Function {
-    Box::new(move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
-        // we are working with utc time
-        let DeltaNow { delta, .. } = DeltaNow::new(args.get("date").unwrap().as_str().unwrap());
-        let num_seconds = delta.num_seconds();
+    Box::new(
+        move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
+            // we are working with utc time
+            let DeltaNow { delta, .. } = DeltaNow::new(args.get("date").unwrap().as_str().unwrap());
+            let num_seconds = delta.num_seconds();
 
-        let s = if delta.num_hours() > 0 {
-            format!("{:>02}:{:>02}", delta.num_hours(), delta.num_minutes() - (delta.num_hours() * 60))
-        } else if delta.num_minutes() > 0 {
-            format!("{:>02}:{:>02}:{:>02}", delta.num_hours(), delta.num_minutes(), num_seconds % 60)
-        } else {
-            format!("{}s", num_seconds)
-        };
-        Ok(tera::to_value(s).unwrap())
-    })
+            let s = if delta.num_hours() > 0 {
+                format!(
+                    "{:>02}:{:>02}",
+                    delta.num_hours(),
+                    delta.num_minutes() - (delta.num_hours() * 60)
+                )
+            } else if delta.num_minutes() > 0 {
+                format!(
+                    "{:>02}:{:>02}:{:>02}",
+                    delta.num_hours(),
+                    delta.num_minutes(),
+                    num_seconds % 60
+                )
+            } else {
+                format!("{}s", num_seconds)
+            };
+            Ok(tera::to_value(s).unwrap())
+        },
+    )
 }


### PR DESCRIPTION
This commit introduces the first light theme for
`taskwarrior-web` with the feature of an automatic
mode to switch between dark and light depending on
OS / Browser setting.

Variable TWK_THEME can be used in order to pre-define
a theme.

Currently only two themes are supported:
1. taskwarrior-dark
2. taskwarrior-light

By default, the theme is switching automatically.

Actually, a small compromise was required in order to make it possible. It was not possible yet to support the default themes as well. Maybe it would be required to override the standard dark/light themes in order to support all themes.

Closes tmahmood/taskwarrior-web#8