### PR TITLE
Feature: Validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,7 +136,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.2",
  "object",
  "rustc-demangle",
 ]
@@ -131,9 +149,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "block-buffer"
@@ -161,6 +179,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,9 +192,12 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.88"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -180,9 +207,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -190,7 +217,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-link",
 ]
 
 [[package]]
@@ -228,6 +255,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -322,6 +358,28 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "flate2"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.8.5",
+]
 
 [[package]]
 name = "fnv"
@@ -435,7 +493,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "ignore",
  "walkdir",
 ]
@@ -445,6 +503,24 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -608,10 +684,11 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -632,6 +709,16 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "lock_api"
@@ -693,6 +780,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -819,7 +915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.57",
  "ucd-trie",
 ]
 
@@ -928,6 +1024,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,9 +1037,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -970,7 +1072,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.2",
- "zerocopy",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -1009,7 +1111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -1064,6 +1166,20 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.9.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -1172,6 +1288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,10 +1341,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "syn"
-version = "2.0.52"
+name = "strum"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1234,6 +1375,26 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "taskchampion"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b010f5ebe51e88ae490691ed2a43b699e3468c8e3838e244accd8526aca7751b"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "chrono",
+ "flate2",
+ "log",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.12",
+ "uuid",
+]
 
 [[package]]
 name = "taskwarrior-web"
@@ -1249,6 +1410,7 @@ dependencies = [
  "rand 0.9.0",
  "serde",
  "serde_json",
+ "taskchampion",
  "tera",
  "tokio",
  "tower 0.5.2",
@@ -1285,7 +1447,16 @@ version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.57",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1293,6 +1464,17 @@ name = "thiserror-impl"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1391,7 +1573,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "bytes",
  "futures-util",
  "http",
@@ -1563,10 +1745,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.1",
+ "serde",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1601,23 +1799,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1626,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1636,9 +1835,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1649,9 +1848,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi"
@@ -1692,6 +1894,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.4",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-sys"
@@ -1831,7 +2039,16 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive 0.7.35",
 ]
 
 [[package]]
@@ -1840,7 +2057,18 @@ version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.20",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ csv = "1.3.1"
 indexmap = { version = "2.2.5", features = ["serde"] }
 rand = "0.9.0-beta.3"
 dotenvy = { version = "0.15.7" }
+taskchampion = { version="2.0.3", default-features = false, features = [] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,7 @@ RUN pacman -Suy --needed --noconfirm curl base-devel npm
 RUN mkdir /app \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh \
     && chmod +x rustup.sh \
-    && ./rustup.sh -y --default-toolchain nightly \
-    # Tailwind
-    && cd /app && curl -o /app/tailwindcss -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 \
-    && chmod +x /app/tailwindcss
+    && ./rustup.sh -y --default-toolchain nightly
 
 FROM rustbase AS buildapp
 # Copy files

--- a/README.md
+++ b/README.md
@@ -99,19 +99,11 @@ By default, the `timewarrior` on-modify hook is installed.
 
 - rust nightly
 - npm
-- tailwindcss-cli
 
 ### Installing rust nightly
 
 Should be installable through `rustup`
 https://rustup.rs/
-
-### Installing tailwindcss-cli
-
-```shell
-curl -o tailwindcss -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64
-chmod +x tailwindcss
-```
 
 ### Building and Running
 

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,6 @@
-use std::{fs, process::Command};
+use std::process::Command;
 
 fn main() {
-    let tailwindcss_bin = fs::canonicalize("./").expect("Cannot determine absolute path to current directory");
-    let tailwindcss_bin = tailwindcss_bin.join("tailwindcss");
-    if !tailwindcss_bin.exists() {
-        panic!("Cannot find tailwindcss binary in {}", tailwindcss_bin.to_string_lossy())
-    }
-
     println!("cargo:rerun-if-changed=frontend/");
     println!("Install npm dependencies");
     if !Command::new("npm")
@@ -19,7 +13,7 @@ fn main() {
         panic!("Could not install dependencies")
     }
 
-    if !Command::new(tailwindcss_bin)
+    if !Command::new("frontend/node_modules/.bin/tailwindcss")
         .args(["-i", "frontend/css/style.css", "-o", "dist/style.css"])
         .status()
         .unwrap()
@@ -28,7 +22,7 @@ fn main() {
         panic!("Failed to process css")
     }
 
-    if !Command::new("frontend/node_modules/rollup/dist/bin/rollup")
+    if !Command::new("frontend/node_modules/.bin/rollup")
         .args(["-c", "frontend/rollup.config.js"])
         .status()
         .unwrap()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,14 +10,15 @@
     "@rollup/plugin-typescript": "^12.1.2",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
-    "daisyui": "^5.0.0-beta.8",
+    "@tailwindcss/cli": "^4.1.3",
+    "daisyui": "^5.0",
     "hotkeys-js": "^3.13.9",
     "htmx.org": "2.0.0-beta4",
     "hyperscript.org": "^0.9.14",
     "postcss": "^8.5.3",
+    "rollup": "^4.38.0",
     "tailwindcss": "^4.0.9",
     "tslib": "^2.8.1",
-    "typescript": "^5.7.3",
-    "rollup": "^4.38.0"
+    "typescript": "^5.7.3"
   }
 }

--- a/frontend/templates/task_add.html
+++ b/frontend/templates/task_add.html
@@ -1,98 +1,149 @@
 {% set bg_color = "bg-neutral-800" %}
-<div class="modal-box">
-    <h2 class="text-lg  font-bold text-neutral-content-50">Adding new task</h2>
+<div class="modal-box" id="modal_add_new_task">
+  <h2 class="text-lg font-bold text-neutral-content-50">Adding new task</h2>
 
-    <form class="mt-2 text-sm" id="task_add_form"
-
-          hx-post="tasks/add"
-          hx-include="[id='filtering']"
-          hx-target="#list-of-tasks"
-    >
-        <div class="my-1">
-            <label
-                    for="desc"
-                    class="block overflow-hidden rounded-md border border-gray-200 px-3 py-2 shadow-sm focus-within:border-blue-600 focus-within:ring-1 focus-within:ring-blue-600 dark:border-neutral-700 dark:{{bg_color}}"
-            >
-                <span class="text-xs font-medium text-gray-700 dark:text-gray-200">Description</span>
-                <input
-                        autofocus
-                        type="text"
-                        id="desc"
-                        name="description"
-                        placeholder="Task description"
-                        class="mt-1 w-full border-none bg-transparent p-0 focus:border-transparent focus:outline-none focus:ring-0 sm:text-sm dark:text-white"
-                />
-            </label>
-        </div>
-
-        <div class="my-1">
-            <label
-                    for="tags"
-                    class="block overflow-hidden rounded-md border border-gray-200 px-3 py-2 shadow-sm focus-within:border-blue-600 focus-within:ring-1 focus-within:ring-blue-600 dark:border-gray-700 dark:{{bg_color}}"
-            >
-                <span class="text-xs font-medium text-gray-700 dark:text-gray-200">Tags</span>
-                <input
-                        type="text"
-                        id="tags"
-                        name="tags"
-                        placeholder="Tags. separate by ,"
-                        value="{{ tags }}"
-                        class="mt-1 w-full border-none bg-transparent p-0 focus:border-transparent focus:outline-none focus:ring-0 sm:text-sm dark:text-white"
-                />
-            </label>
-
-        </div>
-        <div class="my-1">
-            <label
-                    for="project"
-                    class="block overflow-hidden rounded-md border border-gray-200 px-3 py-2 shadow-sm focus-within:border-blue-600 focus-within:ring-1 focus-within:ring-blue-600 dark:border-gray-700 dark:{{bg_color}}"
-            >
-                <span class="text-xs font-medium text-gray-700 dark:text-gray-200">Project</span>
-                <input
-                        type="text"
-                        id="project"
-                        name="project"
-                        placeholder="Project"
-                        value="{{ project }}"
-                        class="mt-1 w-full border-none bg-transparent p-0 focus:border-transparent focus:outline-none focus:ring-0 sm:text-sm dark:text-white"
-                />
-            </label>
-        </div>
-        <div class="my-1">
-            <label
-                    for="additional"
-                    class="block overflow-hidden rounded-md border border-gray-200 px-3 py-2 shadow-sm focus-within:border-blue-600 focus-within:ring-1 focus-within:ring-blue-600 dark:border-neutral-700 dark:{{bg_color}}"
-            >
-                <span class="text-xs font-medium text-gray-700 dark:text-gray-200">Additional options, these will be added to task parameters directly</span>
-                <input
-                        autofocus
-                        type="text"
-                        id="additional"
-                        name="additional"
-                        placeholder="Additional options"
-                        class="mt-1 w-full border-none bg-transparent p-0 focus:border-transparent focus:outline-none focus:ring-0 sm:text-sm dark:text-white"
-                />
-            </label>
-        </div>
-    </form>
-
-    <div class="modal-action" id="model-add-task">
-        <button class="btn btn-md btn-success" id="btn-mdl-yes" form="task_add_form"
-                hx-trigger="click,keyup[key=='Enter']">
-            <kbd class="shortcut_key">Enter</kbd>
-        </button>
-
-        <button class="btn btn-md btn-warning"
-                hx-get="tasks"
-                hx-trigger="click,keyup[key=='Escape'] from:body"
-                hx-include="[id='filtering']"
-                hx-target="#list-of-tasks">
-            <kbd class="shortcut_key">Esc</kbd>
-        </button>
+  <form
+    class="mt-2 text-sm peer {% if not validation.success %}validated{% endif %}"
+    id="task_add_form"
+    hx-post="tasks/add"
+    hx-include="[id='filtering']"
+    hx-target="#modal_add_new_task"
+    hx-swap="outerHTML"
+    hx-on::before-request="this.classList.add('validated')"
+  >
+    <div class="my-1">
+      <label
+        for="desc"
+        class="block overflow-hidden rounded-md border border-gray-200 px-3 py-2 shadow-sm focus-within:border-blue-600 focus-within:ring-1 focus-within:ring-blue-600 dark:border-neutral-700 dark:{{bg_color}}"
+      >
+        <span class="text-xs font-medium text-gray-700 dark:text-gray-200"
+          >Description</span
+        >
+        <input
+          autofocus
+          type="text"
+          id="desc"
+          name="description"
+          value="{{ new_task.description }}"
+          placeholder="Task description"
+          class="mt-1 w-full bg-transparent p-2 focus:outline-none sm:text-sm dark:text-white  {% if validation.fields.description %}border-pink-600 ring-pink-200 input-error input{% else %}border-none focus:ring-0 focus:border-transparent{% endif %}"
+        />
+        {% if validation.fields.description %}
+        <p class="mt-2 [.validated_&]:peer-[:not(:placeholder-shown)]:peer-invalid:block text-pink-600">
+            {% for a in validation.fields.description %}
+            {{ a.message }}
+            {% endfor %}
+        </p>
+        {% endif %}
+      </label>
     </div>
 
-    <script>
-        document.getElementById('all-dialog-boxes').showModal()
-    </script>
+    <div class="my-1">
+      <label
+        for="tags"
+        class="block overflow-hidden rounded-md border border-gray-200 px-3 py-2 shadow-sm focus-within:border-blue-600 focus-within:ring-1 focus-within:ring-blue-600 dark:border-gray-700 dark:{{bg_color}}"
+      >
+        <span class="text-xs font-medium text-gray-700 dark:text-gray-200"
+          >Tags</span
+        >
+        <input
+          type="text"
+          id="tags"
+          name="tags"
+          placeholder="Tags space separated alphanumeric list"
+          value="{{ new_task.tags }}"
+          class="mt-1 w-full bg-transparent p-2 focus:outline-none sm:text-sm dark:text-white {% if validation.fields.tags %}border-pink-600 ring-pink-200 input-error input{% else %}border-none focus:ring-0 focus:border-transparent{% endif %}"
+        />
+        {% if validation.fields.tags %}
+        <p class="mt-2 [.validated_&]:peer-[:not(:placeholder-shown)]:peer-invalid:block text-pink-600">
+            {% for a in validation.fields.tags %}
+            {{ a.message }}
+            {% endfor %}
+        </p>
+        {% endif %}
+      </label>
+    </div>
+    <div class="my-1">
+      <label
+        for="project"
+        class="block overflow-hidden rounded-md border border-gray-200 px-3 py-2 shadow-sm focus-within:border-blue-600 focus-within:ring-1 focus-within:ring-blue-600 dark:border-gray-700 dark:{{bg_color}}"
+      >
+        <span class="text-xs font-medium text-gray-700 dark:text-gray-200"
+          >Project</span
+        >
+        <input
+          type="text"
+          id="project"
+          autocomplete="off"
+          name="project"
+          placeholder="Project"
+          value="{{ new_task.project }}"
+          list="task_add_project_suggest"
+          class="mt-1 w-full bg-transparent p-2 focus:outline-none sm:text-sm dark:text-white {% if validation.fields.project %}border-pink-600 ring-pink-200 input-error input{% else %}border-none focus:ring-0 focus:border-transparent{% endif %}"
+        />
+        {% if validation.fields.project %}
+        <p class="mt-2 [.validated_&]:peer-[:not(:placeholder-shown)]:peer-invalid:block text-pink-600">
+            {% for a in validation.fields.project %}
+            {{ a.message }}
+            {% endfor %}
+        </p>
+        {% endif %}
+      </label>
+      <datalist id="task_add_project_suggest">
+        {% for p in project_list %}<option value="{{ p }}"></option>{% endfor %}
+      </datalist>
+    </div>
+    <div class="my-1">
+      <label
+        for="additional"
+        class="block overflow-hidden rounded-md border border-gray-200 px-3 py-2 shadow-sm focus-within:border-blue-600 focus-within:ring-1 focus-within:ring-blue-600 dark:border-neutral-700 dark:{{bg_color}}"
+      >
+        <span class="text-xs font-medium text-gray-700 dark:text-gray-200"
+          >Additional options, these will be added to task parameters
+          directly</span
+        >
+        <input
+          autofocus
+          type="text"
+          id="additional"
+          name="additional"
+          value="{{ new_task.additional }}"
+          placeholder="Additional options"
+          class="mt-1 w-full bg-transparent p-2 focus:outline-none sm:text-sm dark:text-white {% if validation.fields.additional %}border-pink-600 ring-pink-200 input-error input{% else %}border-none focus:ring-0 focus:border-transparent{% endif %}"
+        />
+        {% if validation.fields.additional %}
+        <p class="mt-2 [.validated_&]:peer-[:not(:placeholder-shown)]:peer-invalid:block text-pink-600">
+            {% for a in validation.fields.additional %}
+            {{ a.message }}
+            {% endfor %}
+        </p>
+        {% endif %}
+      </label>
+    </div>
+  </form>
 
+  <div class="modal-action" id="model-add-task">
+    <button
+      class="btn btn-md btn-success"
+      id="btn-mdl-yes"
+      form="task_add_form"
+      hx-trigger="click,keyup[key=='Enter']"
+    >
+      <kbd class="shortcut_key">Enter</kbd>
+    </button>
+
+    <button
+      class="btn btn-md btn-warning"
+      hx-get="tasks"
+      hx-trigger="click,keyup[key=='Escape'] from:body"
+      hx-include="[id='filtering']"
+      hx-target="#list-of-tasks"
+    >
+      <kbd class="shortcut_key">Esc</kbd>
+    </button>
+  </div>
+
+  <script>
+    document.getElementById("all-dialog-boxes").showModal();
+  </script>
 </div>

--- a/frontend/templates/undo_report.html
+++ b/frontend/templates/undo_report.html
@@ -1,12 +1,52 @@
 <div class="modal-box">
-    <h2 class="text-lg font-bold text-neutral-50">{{ heading }}</h2>
+    <h2 class="text-lg font-bold text-neutral-content-50">{{ heading }}</h2>
     <p class="mt-2 text-sm text-neutral-400">
         The undo command is not reversible. Are you sure you want to revert to the previous state?
-        <ul class="text-neutral-500 text-sm mb-4">
-            {% for line in report %}
-            <li class="mt-2">{{line | replace(from='\t', to='    ') }}</li>
-            {% endfor %}
-        </ul>
+
+        <table class="table table-zebra table-pin-rows table-xs">
+            <thead>
+                <tr>
+                    <th>Uuid</th>
+                    <th>Operation</th>
+                    <th>Change</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for op_uuid, op_list in undo_report %}
+                    {% for operation in op_list %}
+                    <tr>
+                        {% if loop.first %}
+                        <td rowspan="{{ op_list | length }}">{{ operation.uuid }}</td>
+                        {% endif %}
+                        <td>{{ operation.operation }}</td>
+                        <td>{% if operation.property %}
+                            {% if operation.is_tag_change %}
+                                {% if operation.old_value %}
+                                Removed tag {{ operation.property }}
+                                {% else %}
+                                Added tag {{ operation.property }}
+                                {% endif %}
+                            {% else %}
+                                Attribute: {{ operation.property }}<br />
+                                {% if operation.old_value %}
+                                Old value: {{ operation.old_value }}<br />
+                                {% endif %}
+                                New value: {{ operation.value }}<br />
+                                {% endif %}
+                            {% endif %}
+
+                            {% if operation.old_task %}
+                            Following attributes were set:<br />
+                            {% for k,v in operation.old_task %}
+                                {{ k }} = {{ v }}
+                            {% endfor %}
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
     </p>
     <div class="modal-action" id="model-undo">
         <button class="btn btn-warning btn-md"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,0 +1,1 @@
+pub mod task;

--- a/src/backend/task.rs
+++ b/src/backend/task.rs
@@ -1,0 +1,569 @@
+use std::{
+    collections::HashMap,
+    io::Write,
+    os::unix::fs::PermissionsExt,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
+
+use anyhow::Error;
+use chrono::{offset::LocalResult, DateTime, TimeZone, Utc};
+use serde::{Deserialize, Serialize};
+use taskchampion::{Operation, Replica, StorageConfig, Uuid};
+use tracing::{debug, error, info};
+
+use crate::core::errors::AppError;
+
+#[cfg(windows)]
+const LINE_ENDING: &'static str = "\r\n";
+#[cfg(not(windows))]
+const LINE_ENDING: &'static str = "\n";
+
+#[derive(Clone, Debug)]
+pub enum TaskProperties {
+    DESCRIPTION,
+    DUE,
+    MODIFIED,
+    START,
+    STATUS,
+    PRIORITY,
+    WAIT,
+    END,
+    ENTRY,
+    PROJECT,
+}
+
+impl ToString for TaskProperties {
+    fn to_string(&self) -> String {
+        match self {
+            TaskProperties::DESCRIPTION => "description".to_string(),
+            TaskProperties::DUE => "due".to_string(),
+            TaskProperties::MODIFIED => "modified".to_string(),
+            TaskProperties::START => "start".to_string(),
+            TaskProperties::STATUS => "status".to_string(),
+            TaskProperties::PRIORITY => "priority".to_string(),
+            TaskProperties::WAIT => "wait".to_string(),
+            TaskProperties::END => "end".to_string(),
+            TaskProperties::ENTRY => "entry".to_string(),
+            TaskProperties::PROJECT => "project".to_string(),
+        }
+    }
+}
+
+impl TryFrom<&str> for TaskProperties {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let chk_value = value.to_lowercase();
+        let x = vec![
+            Self::DESCRIPTION,
+            Self::DUE,
+            Self::MODIFIED,
+            Self::START,
+            Self::STATUS,
+            Self::PRIORITY,
+            Self::WAIT,
+            Self::END,
+            Self::ENTRY,
+            Self::PROJECT,
+        ];
+        match x.iter().find(|p| p.to_string().eq(&chk_value)) {
+            Some(x) => Ok(x.to_owned()),
+            None => Err(Error::msg(format!(
+                "Property {} is not a reserved property.",
+                &value
+            ))),
+        }
+    }
+}
+
+/// Supported hook events based on taskwarrior definitions.
+///
+/// OnAdd requires executable script named with starting `on-add` and is executed
+/// on new definition of a task.
+/// OnModify requires executable script named with starting `on-modify` and is executed
+/// whenever a task is changed.
+#[derive(Clone, Debug)]
+pub enum TaskEvent {
+    OnAdd,
+    OnModify,
+}
+
+impl ToString for TaskEvent {
+    fn to_string(&self) -> String {
+        match self {
+            TaskEvent::OnAdd => "on-add".to_string(),
+            TaskEvent::OnModify => "on-modify".to_string(),
+        }
+    }
+}
+
+mod task_status_serde {
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(status: &Option<taskchampion::Status>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if let Some(ref d) = *status {
+            let status = match d {
+                taskchampion::Status::Pending => "pending",
+                taskchampion::Status::Completed => "completed",
+                taskchampion::Status::Deleted => "deleted",
+                taskchampion::Status::Recurring => "recurring",
+                taskchampion::Status::Unknown(v) => v.as_ref(),
+            };
+            return s.serialize_str(status);
+        }
+        s.serialize_none()
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<taskchampion::Status>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: Option<String> = Option::deserialize(deserializer)?;
+        if let Some(s) = s {
+            let t = s.to_lowercase();
+            return Ok(Some(match t.as_str() {
+                "pending" => taskchampion::Status::Pending,
+                "completed" => taskchampion::Status::Completed,
+                "deleted" => taskchampion::Status::Deleted,
+                "recurring" => taskchampion::Status::Recurring,
+                &_ => taskchampion::Status::Unknown(t),
+            }));
+        }
+
+        Ok(None)
+    }
+}
+
+mod task_date_format {
+    use chrono::{DateTime, NaiveDateTime, Utc};
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    const FORMAT: &'static str = "%Y%m%dT%H%M%SZ";
+
+    // The signature of a serialize_with function must follow the pattern:
+    //
+    //    fn serialize<S>(&T, S) -> Result<S::Ok, S::Error>
+    //    where
+    //        S: Serializer
+    //
+    // although it may also be generic over the input types T.
+    pub fn serialize<S>(date: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if let Some(dt) = date {
+            let s = format!("{}", dt.format(FORMAT));
+            serializer.serialize_str(&s)
+        } else {
+            serializer.serialize_none()
+        }
+    }
+
+    // The signature of a deserialize_with function must follow the pattern:
+    //
+    //    fn deserialize<'de, D>(D) -> Result<T, D::Error>
+    //    where
+    //        D: Deserializer<'de>
+    //
+    // although it may also be generic over the output types T.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match NaiveDateTime::parse_from_str(&s, FORMAT) {
+            Ok(dt) => Ok(Some(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc))),
+            Err(_) => Ok(None),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TcDateConverter(String);
+
+impl From<&str> for TcDateConverter {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<TcDateConverter> for Option<DateTime<Utc>> {
+    fn from(value: TcDateConverter) -> Self {
+        if let Ok(ts) = value.0.parse::<i64>() {
+            let result = match Utc.timestamp_opt(ts, 0) {
+                LocalResult::Single(tz) => tz,
+                // The other two variants are None and Ambiguous, which both are caused by DST.
+                _ => {
+                    unreachable!("We're requesting UTC so daylight saving time isn't a factor.")
+                }
+            };
+            Some(result)
+        } else {
+            None
+        }
+    }
+}
+
+impl TcDateConverter {
+    fn convert_to_datetime(value: Option<Self>) -> Option<DateTime<Utc>> {
+        if let Some(val_ok) = value {
+            val_ok.into()
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Annotation {
+    entry: DateTime<Utc>,
+    description: String,
+}
+
+impl From<taskchampion::Annotation> for Annotation {
+    fn from(value: taskchampion::Annotation) -> Self {
+        Self {
+            entry: value.entry,
+            description: value.description,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct Task {
+    // id is the relative number within the working set!
+    // to be retrieved with replica.working_set
+    pub id: Option<i64>,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    pub uuid: Uuid,
+    pub urgency: Option<f64>,
+    #[serde(with = "task_date_format")]
+    pub entry: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(with = "task_date_format")]
+    pub start: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(with = "task_date_format")]
+    pub until: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(with = "task_date_format")]
+    pub scheduled: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<Vec<Annotation>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(with = "task_date_format")]
+    pub due: Option<DateTime<Utc>>,
+    pub modified: Option<DateTime<Utc>>,
+    #[serde(default, with = "task_status_serde")]
+    pub status: Option<taskchampion::Status>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(with = "task_date_format")]
+    pub wait: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub depends: Option<Vec<Uuid>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recur: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mask: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub imask: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "UDA")]
+    pub uda: Option<HashMap<String, String>>,
+}
+
+impl From<taskchampion::Task> for Task {
+    fn from(value: taskchampion::Task) -> Self {
+        let tags: Vec<String> = value
+            .get_tags()
+            .filter(|p| p.is_user())
+            .map(|p| p.to_string())
+            .collect();
+        let deps: Vec<Uuid> = value.get_dependencies().collect();
+        let annotations: Vec<Annotation> = value
+            .get_annotations()
+            .map(|p| Annotation::from(p))
+            .collect();
+        let uda: HashMap<String, String> = value
+            .get_user_defined_attributes()
+            .map(|p| (p.0.to_string(), p.1.to_string()))
+            .collect();
+
+        Task {
+            id: None,
+            uuid: value.get_uuid(),
+            description: value.get_description().to_string(),
+            tags: Some(tags),
+            depends: Some(deps),
+            end: value.get_value("start").map(|p| p.to_string()),
+            project: value
+                .get_value(TaskProperties::PROJECT.to_string())
+                .map(|p| p.to_string()),
+            urgency: value
+                .get_value("urgency")
+                .map(|p| p.parse::<f64>().unwrap_or_default()),
+            // timestamp
+            entry: TcDateConverter::convert_to_datetime(value.get_value("entry").map(|p| p.into())),
+            // timestamp
+            start: TcDateConverter::convert_to_datetime(value.get_value("start").map(|p| p.into())),
+            // timestamp
+            until: TcDateConverter::convert_to_datetime(value.get_value("until").map(|p| p.into())),
+            scheduled: TcDateConverter::convert_to_datetime(
+                value.get_value("scheduled").map(|p| p.into()),
+            ),
+            annotations: Some(annotations),
+            due: value.get_due(),
+            modified: value.get_modified(),
+            status: Some(value.get_status()),
+            wait: value.get_wait(),
+            priority: Some(value.get_priority().to_string()),
+            recur: value.get_value("recur").map(|p| p.to_string()),
+            mask: value.get_value("mask").map(|p| p.to_string()),
+            imask: value
+                .get_value("imask")
+                .map(|p| p.parse::<f64>().unwrap_or_default()),
+            parent: value.get_value("parent").map(|p| p.to_string()),
+            uda: Some(uda),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskOperation {
+    pub operation: String,
+    pub uuid: Uuid,
+    pub property: Option<String>,
+    pub old_value: Option<String>,
+    pub value: Option<String>,
+    pub timestamp: Option<DateTime<Utc>>,
+    pub old_task: Option<HashMap<String, String>>,
+    pub is_tag_change: bool,
+}
+
+/// Get a replica access to the taskchampion database stored in `taskdb`
+pub fn get_replica(taskdb: &PathBuf) -> Result<Replica, anyhow::Error> {
+    // Create a new Replica, storing data on disk.
+    let storage = StorageConfig::OnDisk {
+        taskdb_dir: taskdb.to_path_buf(),
+        create_if_missing: true,
+        access_mode: taskchampion::storage::AccessMode::ReadWrite,
+    }
+    .into_storage()?;
+    Ok(Replica::new(storage))
+}
+
+/// Execute all hooks compliant to taskwarrior specification.
+pub fn execute_hooks(
+    hooks_dir: &Option<PathBuf>,
+    event_type: &TaskEvent,
+    old: &Option<Task>,
+    new: &Option<Task>,
+) -> Result<(), anyhow::Error> {
+    if hooks_dir.is_none() {
+        return Ok(());
+    }
+
+    let old_task = old
+        .as_ref()
+        .map(|f| serde_json::to_string(&f).unwrap_or("".to_string()))
+        .unwrap_or("".to_string());
+    let new_task = new
+        .as_ref()
+        .map(|f| serde_json::to_string(&f).unwrap_or("".to_string()))
+        .unwrap_or("".to_string());
+
+    let mut args = String::new();
+    match event_type {
+        TaskEvent::OnAdd => {}
+        TaskEvent::OnModify => {
+            args.push_str(&old_task);
+            args.push_str(LINE_ENDING);
+        }
+    };
+    args.push_str(&new_task);
+    args.push_str(LINE_ENDING);
+
+    // find scripts and execute.
+    let hooks_dir = hooks_dir.as_ref().unwrap();
+    let paths = std::fs::read_dir(&hooks_dir)?;
+    for path in paths {
+        if let Ok(entry) = path {
+            if let Ok(meta) = entry.metadata() {
+                let permissions = meta.permissions();
+                let is_executable = permissions.mode() & 0o111 != 0;
+                if meta.is_file()
+                    && entry
+                        .file_name()
+                        .to_str()
+                        .unwrap()
+                        .starts_with(&event_type.to_string())
+                    && is_executable
+                {
+                    debug!(
+                        "Hook {:?} will be executed with stdin: {}",
+                        &entry.file_name().to_str(),
+                        &args
+                    );
+                    let child = Command::new(entry.path())
+                        .stdin(Stdio::piped())
+                        .stdout(Stdio::piped())
+                        .spawn();
+                    match child {
+                        Ok(mut child) => {
+                            let child_stdin = child.stdin.as_mut().unwrap();
+                            let _ = child_stdin.write_all(args.as_bytes());
+
+                            let cmd = child.wait_with_output();
+                            match cmd {
+                                Ok(o) => {
+                                    let output = [o.stdout.as_slice()].concat();
+                                    let output = String::from_utf8(output)
+                                        .unwrap_or("Output no valid UTF-8".to_string());
+                                    info!(
+                                        "Hook {:?} called, exit status: {}",
+                                        &entry.file_name().to_str(),
+                                        o.status
+                                    );
+                                    debug!(
+                                        "Hook {:?} output was {:?}",
+                                        &entry.file_name().to_str(),
+                                        output
+                                    );
+                                }
+                                Err(e) => {
+                                    error!(
+                                        "Hook {:?} failed with error {}",
+                                        &entry.file_name().to_str(),
+                                        e.to_string()
+                                    );
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            error!(
+                                "Hook {:?} failed with error {}",
+                                &entry.file_name().to_str(),
+                                e.to_string()
+                            );
+                        }
+                    };
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Gives a dedup list of projects in the given taskchampion data source.
+pub fn get_project_list(taskdb: &PathBuf) -> Result<Vec<String>, AppError> {
+    let mut replica = get_replica(taskdb)?;
+    let mut x: Vec<String> = replica
+        .all_task_data()?
+        .values()
+        .map(|f| f.get(TaskProperties::PROJECT.to_string()))
+        .filter(|p| p.is_some_and(|f| !f.is_empty()))
+        .map(|p| p.expect("Value given!").to_string())
+        .collect();
+    x.sort();
+    x.dedup();
+
+    Ok(x)
+}
+
+/// Get a list of tags used in any of current worksets replica content.
+#[allow(dead_code)]
+fn get_tag_list(taskdb: &PathBuf) -> Result<Vec<String>, AppError> {
+    let mut replica = get_replica(taskdb)?;
+    let mut tags: Vec<String> = vec![];
+
+    for task in replica.all_task_data()? {
+        for f in task.1.properties().filter(|x| x.starts_with("tag_")) {
+            let tag_name = f.strip_prefix("tag_").unwrap_or(f);
+            tags.push(tag_name.to_owned());
+        }
+    }
+    tags.sort();
+    tags.dedup();
+
+    Ok(tags)
+}
+
+pub fn get_undo_operations(taskdb: &PathBuf) -> Result<HashMap<Uuid, Vec<TaskOperation>>, AppError> {
+    let mut replica = get_replica(taskdb)?;
+    let ops = replica.get_undo_operations()?;
+    let mut converted_ops: HashMap<Uuid, Vec<TaskOperation>> = HashMap::new();
+    for e in ops {
+        let converted_entry = match e {
+            Operation::Create { uuid } => Some((uuid.clone(), TaskOperation {
+                operation: "Create".to_string(),
+                uuid,
+                property: None,
+                old_value: None,
+                value: None,
+                timestamp: None,
+                old_task: None,
+                is_tag_change: false,
+            })),
+            Operation::Delete { uuid, old_task } => Some((uuid.clone(), TaskOperation {
+                operation: "Delete".to_string(),
+                uuid,
+                property: None,
+                old_value: None,
+                value: None,
+                timestamp: None,
+                old_task: Some(old_task),
+                is_tag_change: false,
+            })),
+            Operation::Update {
+                uuid,
+                property,
+                old_value,
+                value,
+                timestamp,
+            } => {
+                let is_tag_change = &property.starts_with("tag_");
+                let property = match is_tag_change {
+                    true => property
+                        .strip_prefix("tag_")
+                        .unwrap_or(&property)
+                        .to_string(),
+                    false => property,
+                };
+                Some((uuid.clone(), TaskOperation {
+                    operation: "Modified".to_string(),
+                    uuid,
+                    property: Some(property),
+                    old_value,
+                    value,
+                    timestamp: Some(timestamp),
+                    old_task: None,
+                    is_tag_change: *is_tag_change,
+                }))
+            }
+            Operation::UndoPoint => None,
+        };
+        if let Some(top) = converted_entry {
+            if let Some(op_list) = converted_ops.get_mut(&top.0) {
+                op_list.push(top.1);
+            } else {
+                converted_ops.insert(top.0, vec![top.1]);
+            }
+        }
+    }
+    Ok(converted_ops)
+}

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -1,0 +1,68 @@
+use std::{env::{self, home_dir}, path::PathBuf, str::FromStr};
+use tera::Context;
+
+/// Holds state information and configurations
+/// required in the API and business logic operations.
+/// 
+/// # Environments
+/// Many of the options are configured via environment variables.
+/// Following are supported:
+/// | Environment variable      | AppState field           |
+/// |---------------------------|--------------------------|
+/// | TWK_USE_FONT              | font                     |
+/// | TWK_THEME                 | theme                    |
+/// | DISPLAY_TIME_OF_THE_DAY   | display_time_of_the_day  |
+/// | TASKDATA                  | task_storage_path        |
+/// 
+#[derive(Clone, Debug)]
+pub struct AppState {
+    pub font: Option<String>,
+    pub fallback_family: String,
+    pub theme: Option<String>,
+    pub display_time_of_the_day: i32,
+    pub task_storage_path: PathBuf,
+    pub task_hooks_path: Option<PathBuf>,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        let font = env::var("TWK_USE_FONT").map(|p| Some(p)).unwrap_or(None);
+        let theme = match env::var("TWK_THEME") {
+            Ok(p) if p.is_empty() => None,
+            Ok(p) => Some(p),
+            Err(_) => None,
+        };
+        let display_time_of_the_day = env::var("DISPLAY_TIME_OF_THE_DAY")
+            .unwrap_or("0".to_string())
+            .parse::<i32>()
+            .unwrap_or(0);
+
+        let home_dir = home_dir().unwrap_or(PathBuf::default());
+        let home_dir = home_dir.join(".task");
+        let task_storage_path =
+            env::var("TASKDATA").unwrap_or(home_dir.to_str().unwrap_or("").to_string());
+        let task_storage_path = PathBuf::from_str(&task_storage_path)
+            .expect("Storage path cannot be found");
+        let task_hooks_path = Some(home_dir.clone().join("hooks"));
+
+        Self {
+            font: font,
+            fallback_family: "monospace".to_string(),
+            theme: theme,
+            display_time_of_the_day: display_time_of_the_day,
+            task_storage_path: task_storage_path,
+            task_hooks_path: task_hooks_path,
+        }
+    }
+}
+
+impl From<&AppState> for Context {
+    fn from(val: &AppState) -> Self {
+        let mut ctx = Context::new();
+        ctx.insert("USE_FONT", &val.font);
+        ctx.insert("FALLBACK_FAMILY", &val.fallback_family);
+        ctx.insert("DEFAULT_THEME", &val.theme);
+        ctx.insert("display_time_of_the_day", &val.display_time_of_the_day);
+        ctx
+    }
+}

--- a/src/core/errors.rs
+++ b/src/core/errors.rs
@@ -1,0 +1,128 @@
+use std::collections::HashMap;
+
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde::{Deserialize, Serialize};
+
+pub struct AppError(anyhow::Error);
+
+// Tell axum how to convert `AppError` into a response.
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Something went wrong: {}", self.0),
+        )
+            .into_response()
+    }
+}
+
+// This enables using `?` on functions that return `Result<_, anyhow::Error>` to turn them into
+// `Result<_, AppError>`. That way you don't need to do that manually.
+impl<E> From<E> for AppError
+where
+    E: Into<anyhow::Error>,
+{
+    fn from(err: E) -> Self {
+        Self(err.into())
+    }
+}
+
+impl ToString for AppError {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FieldError {
+    pub field: String,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FormValidation {
+    pub fields: HashMap<String, Vec<FieldError>>,
+    pub msg: Option<String>,
+    success: bool,
+}
+
+impl Default for FormValidation {
+    fn default() -> Self {
+        Self {
+            fields: Default::default(),
+            msg: None,
+            success: true,
+        }
+    }
+}
+
+impl std::fmt::Display for FormValidation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let field_list: Vec<String> = self.fields.values().map(|f| {
+            let msg_list: Vec<String> = f.iter().map(|x| format!("{}={}", x.field.to_string(), x.message.to_string())).collect();
+            msg_list.join(", ")
+        }).collect();
+        write!(f, "FormValidation error was {:?}, affected fields: {}", self.success, field_list.join("; "))
+    }
+}
+
+impl std::error::Error for FormValidation {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+
+    fn description(&self) -> &str {
+        "description() is deprecated; use Display"
+    }
+
+    fn cause(&self) -> Option<&dyn std::error::Error> {
+        self.source()
+    }
+}
+
+impl From<anyhow::Error> for FormValidation {
+    fn from(value: anyhow::Error) -> Self {
+        Self::default().set_error(Some(&value.to_string())).to_owned()
+    }
+}
+
+impl From<taskchampion::Error> for FormValidation {
+    fn from(value: taskchampion::Error) -> Self {
+        Self::default().set_error(Some(&value.to_string())).to_owned()
+    }
+}
+
+impl FormValidation {
+    pub fn push(&mut self, error: FieldError) -> () {
+        self.success = false;
+        if let Some(val) = self.fields.get_mut(&error.field) {
+            val.push(error);
+        } else {
+            self.fields.insert(error.field.to_string(), vec![error]);
+        }
+    }
+
+    pub fn is_success(&self) -> bool {
+        self.success
+    }
+
+    pub fn set_error(&mut self, msg: Option<&str>) -> &Self {
+        if let Some(err_msg) = msg {
+            self.success = false;
+            self.msg = Some(err_msg.to_string());
+        } else {
+            self.success = !self.fields.is_empty();
+            self.msg = None;
+        }
+
+        self
+    }
+
+    pub fn has_error(&self, field: &str) -> bool {
+        self.fields.contains_key(field)
+    }
+
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,2 @@
+pub mod errors;
+pub mod app;


### PR DESCRIPTION
This commit brings a validation handling on task creation. This implies additional changes integrated:

 - DaisyUI was upgraded
 - Hooks were implemented as using Taskchampion is not calling the original taskwarrior hooks anymore.
 - Undo report is getting the data now from taskchampion for better usability

Error indication:
![image](https://github.com/user-attachments/assets/4d3bcd8f-1528-4263-9b8e-2bd0e34b8338)

Interestingly i figured out, that depending how you create the tags in the task command line interface, you will be able to assign invalid tags. Even with a sign in front of a tag. So it seems that taskchampion is better validating the data than task itself.

Undo report example:
![image](https://github.com/user-attachments/assets/8b3bcde5-abea-4d17-be24-946a6122ba2f)

I would not had to change the undo report yet. But my inner Monk forced me to do it. If I should split and send as separate request, let me know.

Closes #10 

Dear @tmahmood ,
maybe you can try it out on your side whether this is working fine for you as well or if there are further improvements in this case necessary.

I've many further ideas in this, but do not want to bloat this MR too much. It contains already much more things i initial planned.

Best regards,
monofox