### PR TITLE
Bugfix: Task status not changeable

### DIFF
--- a/src/backend/task.rs
+++ b/src/backend/task.rs
@@ -77,6 +77,16 @@ impl TryFrom<&str> for TaskProperties {
     }
 }
 
+pub fn convert_task_status(task_status: String) -> taskchampion::Status {
+    match task_status.as_str() {
+        "pending" => taskchampion::Status::Pending,
+        "completed" => taskchampion::Status::Completed,
+        "deleted" => taskchampion::Status::Deleted,
+        "recurring" => taskchampion::Status::Recurring,
+        &_ => taskchampion::Status::Unknown(task_status),
+    }
+}
+
 /// Supported hook events based on taskwarrior definitions.
 ///
 /// OnAdd requires executable script named with starting `on-add` and is executed
@@ -100,6 +110,8 @@ impl ToString for TaskEvent {
 
 mod task_status_serde {
     use serde::{self, Deserialize, Deserializer, Serializer};
+
+    use super::convert_task_status;
 
     pub fn serialize<S>(status: &Option<taskchampion::Status>, s: S) -> Result<S::Ok, S::Error>
     where
@@ -125,13 +137,7 @@ mod task_status_serde {
         let s: Option<String> = Option::deserialize(deserializer)?;
         if let Some(s) = s {
             let t = s.to_lowercase();
-            return Ok(Some(match t.as_str() {
-                "pending" => taskchampion::Status::Pending,
-                "completed" => taskchampion::Status::Completed,
-                "deleted" => taskchampion::Status::Deleted,
-                "recurring" => taskchampion::Status::Recurring,
-                &_ => taskchampion::Status::Unknown(t),
-            }));
+            return Ok(Some(convert_task_status(t)));
         }
 
         Ok(None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,10 @@ use std::string::ToString;
 use taskwarrior_web::backend::task::{get_project_list, TaskOperation};
 use taskwarrior_web::core::app::AppState;
 use taskwarrior_web::core::errors::FormValidation;
-use taskwarrior_web::endpoints::tasks;
+use taskwarrior_web::endpoints::tasks::{self, change_task_status};
 use taskwarrior_web::endpoints::tasks::task_query_builder::TaskQuery;
 use taskwarrior_web::endpoints::tasks::{
-    fetch_active_task, get_task_details, list_tasks, mark_task_as_done, run_annotate_command,
+    fetch_active_task, get_task_details, list_tasks, run_annotate_command,
     run_denotate_command, run_modify_command, task_add, task_undo, toggle_task_active, Task,
     TaskUUID, TaskViewDataRetType,
 };
@@ -433,7 +433,7 @@ async fn do_task_actions(
     let fm = match multipart.action().clone().unwrap() {
         TaskActions::StatusUpdate => {
             if let Some(task) = taskwarrior_web::from_task_to_task_update(&multipart) {
-                match mark_task_as_done(task.clone(), &app_state) {
+                match change_task_status(task.clone(), &app_state) {
                     Ok(_) => FlashMsg::new(&format!("Task [{}] was updated", task.uuid), None),
                     Err(e) => {
                         error!("Failed: {}", e);


### PR DESCRIPTION
This commit fixes a bug introduced with ticket #10 and MR #13. The `mask_task_as_done` did what it was named for. It completed tasks. Due to this, it was not possible anymore, to re-activate a ticket back to pending.