### PR TITLE
remove RUN without argument in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM archlinux:latest AS rustbase
 RUN pacman -Suy --needed --noconfirm curl base-devel npm 
-RUN 
 RUN mkdir /app \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh \
     && chmod +x rustup.sh \


### PR DESCRIPTION
because RUN without args leads to `/bin/sh: -c: option requires an argument` on my machine