### PR TITLE
Improve task update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
@@ -1286,6 +1286,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
@@ -1410,6 +1416,8 @@ dependencies = [
  "rand 0.9.0",
  "serde",
  "serde_json",
+ "serde_path_to_error",
+ "shell-words",
  "taskchampion",
  "tera",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,5 @@ indexmap = { version = "2.2.5", features = ["serde"] }
 rand = "0.9.0-beta.3"
 dotenvy = { version = "0.15.7" }
 taskchampion = { version="2.0.3", default-features = false, features = [] }
+serde_path_to_error = "0.1.17"
+shell-words = "1.1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN echo "NoExtract = !usr/share/doc/timew/*" >> /etc/pacman.conf \
  && mkdir -p /app/.timewarrior/data/ \
  && systemctl enable cronie.service \
  && cp /usr/share/doc/timew/ext/on-modify.timewarrior /app/.task/hooks/on-modify.timewarrior \
+ && chmod +x /app/.task/hooks/on-modify.timewarrior \
  && ( [[ $TASK_ADDON_BUGWARRIOR != "true" ]] || python3 -m pip install --break-system-packages bugwarrior[$TASK_ADDON_BUGWARRIOR_FEATURES]@git+https://github.com/GothenburgBitFactory/bugwarrior.git ) \
  # cleanup
  && pacman --noconfirm -R git python-pip \ 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -18,4 +18,3 @@ fi
 
 cd $HOME/bin
 exec ./taskwarrior-web
-

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -15,7 +15,7 @@ hotkeys.filter = function (event) {
     let tagName = event.target.tagName;
     hotkeys.setScope(/^(INPUT|TEXTAREA|SELECT)$/.test(tagName) ? 'input' : 'other');
     return true;
-}
+};
 
 function focusTextInput(event: KeyboardEvent | MouseEvent) {
     let ss = document.getElementById('task-details-inp');
@@ -24,6 +24,36 @@ function focusTextInput(event: KeyboardEvent | MouseEvent) {
         ss.focus();
     } else {
         document.getElementById('cmd-inp').focus();
+    }
+}
+
+window.handleTaskAnnotations = (event: KeyboardEvent | MouseEvent) => {
+    if(event.target != document.getElementById('btn-denotate-task')) {
+        console.log("not processing")
+        return
+    }
+    event.preventDefault();
+    let annoSelector = document.getElementById('anno-inp');
+    document.querySelector('#anno-inp').classList.toggle('hidden');
+    Array.from(document.querySelectorAll('.is-a-annotation')).forEach((value) => {
+        value.classList.toggle('hidden');
+    });
+    if (annoSelector.checkVisibility()) {
+        annoSelector.focus();
+    }
+    return false;
+};
+
+window.handleTaskAnnotationTrigger = (event: KeyboardEvent | MouseEvent) => {
+    event.preventDefault();
+    if (event.target) {
+        let shortkey = event.target.value;
+        if (shortkey.length >= 2) { 
+            let element = document.getElementById("anno_dlt_" + shortkey);
+            if (element) {
+                element.click();
+            }
+        };
     }
 }
 
@@ -89,6 +119,7 @@ document.addEventListener("DOMContentLoaded", function () {
     let n = setInterval(
         () => {
             let whichOne = 0;
+            // document.getElementById('active-timer').querySelectorAll('span.timer-duration')[0]
             let dd = document.getElementById('active-timer');
             if (dd === undefined || dd === null) {
                 return

--- a/frontend/templates/active_task.html
+++ b/frontend/templates/active_task.html
@@ -3,10 +3,11 @@
     <div class="join">
 
     </div>
-    <div class="pl-2.5 pr-6 py-1.5 bg-green-900 text-green-200 shadow-xl rounded-sm flex flex-wrap " id="active-timer">
+    <div class="pl-2.5 pr-6 py-1.5 bg-green-900 text-green-200 shadow-xl rounded-sm flex flex-wrap " id="active-timer" 
+        data-task-id="{{ active_task.uuid }}" data-task-start="{{ active_task.start }}">
         <span class="flex-grow">{{ active_task.description }}</span>
         <div class="join">
-            <span class="badge badge-success badge-md badge-soft join-item">
+            <span class="badge badge-success badge-md badge-soft join-item timer-duration">
                 {{ timer_value(date=active_task.start) }}
             </span>
             <button class="btn btn-accent btn-xs join-item"
@@ -14,7 +15,7 @@
                     hx-target="#list-of-tasks"
                     hx-swap="innerHTML"
                     hx-include="[id='filtering']"
-                    hx-vals='{"uuid":"{{ active_task.uuid }}", "action": "ToggleTimer"}'
+                    hx-vals='{"uuid":"{{ active_task.uuid }}", "action": "ToggleTimer", "status": "stop"}'
                     hx-trigger="click,keyup[key=='o'] from:#cmd-inp">
                 <span>St<span class="shortcut_key">o</span>p</span>
             </button>

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -17,7 +17,7 @@
 <body>
 <div id="content" class="px-5">
     <main>
-        <div class="toast" id="toast"></div>
+        <div class="toast fixed items-center right-5 bottom-5 w-full max-w-xs" id="toast" role="alert"></div>
         <div id="list-of-tasks">{% include "tasks.html" %}</div>
         <div id="ledger_things"></div>
     </main>

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -17,7 +17,7 @@
 <body>
 <div id="content" class="px-5">
     <main>
-        <div class="toast fixed items-center right-5 bottom-5 w-full max-w-xs" id="toast" role="alert"></div>
+        <div class="toast fixed items-center right-5 bottom-5 w-full max-w-xs z-605" id="toast" role="alert"></div>
         <div id="list-of-tasks">{% include "tasks.html" %}</div>
         <div id="ledger_things"></div>
     </main>

--- a/frontend/templates/flash_msg.html
+++ b/frontend/templates/flash_msg.html
@@ -1,14 +1,31 @@
-<div class="items-center justify-center gap-4 rounded-lg bg-black px-5 py-3 text-white z-50"
-     hx-trigger="load delay:{{ timeout }}s" hx-get="/msg_clr" id="flash_msg" hx-swap="outerHTML">
-    <span class="text-sm font-medium hover:opacity-75">{{ msg }} {{ timeout }}</span>
-    <button class="rounded bg-white/20 p-1 hover:bg-white/10" hx-get="/msg_clr" hx-target="#toast" hx-swap="innerHTML">
-        <span class="sr-only">Close ,,,</span>
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-            <path
-                    fillRule="evenodd"
-                    d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                    clipRule="evenodd"
-            />
-        </svg>
-    </button>
+<!-- Force generation of types: <div class="alert-success alert-error alert-warning"></div> -->
+<div
+  class="items-center justify-center gap-4 rounded-lg px-5 py-3 z-50 toast-item alert {% if toast_role %}alert-{{toast_role}}{% else %}alert-info{% endif %}"
+  id="flash_msg"
+  hx-trigger="load delay:{{ toast_timeout }}s" hx-get="/msg_clr"
+  hx-swap="outerHTML"
+  role="alert"
+>
+  <span class="text-sm font-medium hover:opacity-75">{{ toast_msg }}</span>
+  <button
+    class="rounded bg-white/20 p-1 hover:bg-white/10 pointer"
+    hx-get="/msg_clr" hx-target="#toast"
+    hx-trigger="click,keyup[key=='Escape'] from:#cmd-inp"
+    autofocus
+    hx-swap="innerHTML"
+  >
+    <span class="sr-only">Close ,,,</span>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-4 w-4"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+    >
+      <path
+        fillRule="evenodd"
+        d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+        clipRule="evenodd"
+      />
+    </svg>
+  </button>
 </div>

--- a/frontend/templates/task_action_bar.html
+++ b/frontend/templates/task_action_bar.html
@@ -9,6 +9,7 @@
     ><span><span class="shortcut_key">ESC</span></span></button>
     <label for="task-inp" class="hidden"></label>
     <input type="text" id="task-inp"
+           autocomplete="off"
            class="input input-neutral input-xs join-item"
            placeholder="Enter Shortcut"
            hx-trigger="changes delay:2s"

--- a/frontend/templates/task_delete_confirm.html
+++ b/frontend/templates/task_delete_confirm.html
@@ -1,0 +1,145 @@
+<div class="modal-box">
+    <h2 class="text-lg font-bold text-neutral-content-50">Delete: {{ task.description }}</h2>
+    <p class="mt-2 text-sm text-content">
+        Deleting a task will stop any operation on the task and will finally delete it. This operation can still be reverted.
+        Are you sure you want to delete the task?
+    </p>
+    <p class="mt-2 text-sm text-content">
+        <table class="table table-xs table-zebra">
+            <tbody>
+              <tr>
+                <th>Description</th>
+                <td class="text-wrap w-2/3">
+                    {{ task.description }}
+                </td>
+              </tr>
+              <tr>
+                <th>Uuid</th>
+                <td class="text-wrap w-2/3">
+                    {{ task.uuid }}
+                </td>
+              </tr>
+                <tr>
+                    <th>Age</th>
+                    <td>
+                    {% if task.entry %}{{ date_proper(date=task.entry) }} ({{ date(date=task.entry) }}){% endif %}
+                    </td>
+                </tr>
+                <tr>
+                    <th>Depends on</th>
+                    <td>
+                    {% if task.depends %} {% for dep_task in tasks_db %}
+                    <button
+                        class="btn btn-secondary btn-xs is-a-tag join-item {%if dep_task.status == 'completed'%}btn-outline{% endif %}"
+                        hx-trigger="click"
+                        hx-get="tasks/{{dep_task.uuid}}/details"
+                        hx-target="#task-details-modal-box"
+                        hx-swap="outerHTML"
+                        title="{{dep_task.description}}"
+                    >
+                        {% if dep_task.status == 'completed' %}
+                        ✓
+                        {% endif %}
+                        {% if dep_task.id %}
+                        {{dep_task.id}}
+                        {% else %}
+                        {{dep_task.uuid}}
+                        {% endif %}
+                    </button>
+                    {% endfor %} {% endif %}
+                    </td>
+                </tr>
+                <tr>
+                    <th>Project</th>
+                    <td>
+                    {% if task.project %}
+                    <div class="breadcrumbs text-sm">
+                        <ul>
+                        {% for p in task.project | split(pat=".") %}
+                        <li class="">{{ p }}</li>
+                        {% endfor %}
+                        </ul>
+                    </div>
+                    {% endif %}
+                    </td>
+                </tr>
+                <tr>
+                    <th>Tags</th>
+                    <td>
+                    <div>
+                        {% if task.tags %} {% for p in task.tags %}
+                        <span class="badge-sm badge badge-accent"> {{ p }} </span>
+                        {% endfor %} {% endif %} {% if task.priority %}
+                        <span class="badge badge-sm badge-secondary"
+                        >{{ task.priority }}</span
+                        >
+                        {% endif %}
+                    </div>
+                    </td>
+                </tr>
+                <tr>
+                    <th>Urgency</th>
+                    <td>{{ task.urgency }}</td>
+                </tr>
+                <tr>
+                    {% if task.start %}
+                    <th>Start</th>
+                    <td>{{ date_proper(date=task.start) }}</td>
+                </tr>
+                <tr>
+                    {% endif %} {% if task.due and task.status != 'completed' %}
+                    <th>Due</th>
+                    <td>{{ date_proper(date=task.due, in_future=true) }} ({{ date(date=task.due) }})</td>
+                    {% endif %}
+                </tr>
+                <tr>
+                    {% if task.scheduled %}
+                    <th>Scheduled</th>
+                    <td>{{ date_proper(date=task.scheduled, in_future=true) }}  ({{ date(date=task.scheduled) }})</td>
+                    {% endif%}
+                </tr>
+                <tr>
+                    {% if task.wait %}
+                    <th>Wait until</th>
+                    <td>{{ date_proper(date=task.wait, in_future=true) }}  ({{ date(date=task.wait) }})</td>
+                    {% endif%}
+                </tr>
+                <tr>
+                    {% if task.end %}
+                    <th>End</th>
+                    <td>{{ date_proper(date=task.end) }} ({{ date(date=task.end) }})</td>
+                    {% endif %}
+                </tr>
+                <tr>
+                    {% if task.recur %}
+                    <th>RECUR</th>
+                    <td>{{task.recur}}</td>
+                    {% endif %}
+                </tr>
+            </tbody>
+        </table>
+    </p>
+    <div class="modal-action" id="model-task-delete">
+        <button class="btn btn-warning btn-md"
+                id="btn-mdl-yes"
+                hx-include="[id='filtering']"
+                hx-target="#list-of-tasks"
+                hx-post="tasks"
+                hx-vals='{"status": "deleted", "uuid":"{{ task.uuid }}", "action": "StatusUpdate"}'
+                hx-trigger="click,keyup[key=='Enter'] from:body">
+            <kbd class="shortcut_key">Enter</kbd> Yes, Sure
+        </button>
+
+        <button  class="btn btn-success btn-md"
+                hx-get="tasks/{{ task.uuid }}/details"
+                hx-trigger="click,keyup[key=='Escape'] from:body"
+                hx-include="[id='filtering']"
+                hx-target="#all-dialog-boxes"
+            >
+            <kbd class="shortcut_key">Esc</kbd> Cancel
+        </button>
+    </div>
+    <script>
+        document.getElementById('all-dialog-boxes').showModal()
+    </script>
+</div>

--- a/frontend/templates/task_details.html
+++ b/frontend/templates/task_details.html
@@ -1,203 +1,300 @@
 {% import "desc.html" as desc %}
-<div class="modal-box">
-    <h2 class="text-lg font-bold text-neutral-content-200">Task Details</h2>
-    <div class="join mb-3">
-        <button class="btn btn-xs btn-warning join-item"
-                id="tag-btn-back-details"
-                hx-get="tasks"
-                hx-target="#list-of-tasks"
-                hx-include="[id='filtering']"
-                hx-trigger="click,keyup[key=='Escape'] from:#task-details-inp">
-            <kbd class="shortcut_key">Esc</kbd>
-        </button>
-        <button
-                class="btn btn-success btn-xs join-item"
-                id="btn-mark-as-done"
-                hx-post="tasks"
-                hx-target="#list-of-tasks"
-                hx-include="[id='filtering']"
-                {% if task.status !="completed" %}
-                    hx-vals='{"status": "completed", "uuid":"{{ task.uuid }}", "action": "StatusUpdate"}'
-                {% else %}
-                    hx-vals='{"status": "pending", "uuid":"{{ task.uuid }}", "query": "status:completed", "action": "StatusUpdate" }'
-                {% endif %}
-                hx-trigger="click,keyup[key=='d'] from:#task-details-inp"
-        ><span><span class="shortcut_key">d</span>one</span></button>
-        <button
-                class="btn btn-accent btn-xs join-item"
-                id="btn-denotate-task"
-                hx-post="tasks"
-                hx-target="#list-of-tasks"
-                hx-include="[id='filtering']"
-                hx-vals='{"uuid":"{{ task.uuid }}", "action": "DenotateTask"}'
-                hx-trigger="click,keyup[key=='n'] from:#task-details-inp"
-        >
-            <span>de<span class="shortcut_key">n</span>otate</span>
-        </button>
-        <button
-                class="btn btn-info btn-xs join-item"
-                id="btn-timer-toggle"
-                hx-post="tasks"
-                hx-target="#list-of-tasks"
-                hx-include="[id='filtering']"
-                hx-vals='{"uuid":"{{ task.uuid }}", "action": "ToggleTimer"}'
-                hx-trigger="click,keyup[key=='s'] from:#task-details-inp">
-            <span>
-            {% if task.start %}
-                <span class="shortcut_key">s</span>top
+<div class="modal-box max-w-3xl" id="task-details-modal-box">
+  <h2 class="text-lg font-bold text-neutral-content-200">Task: {{ task.description }}</h2>
+  <div class="join mb-3">
+    <button
+      class="btn btn-xs btn-warning join-item"
+      id="tag-btn-back-details"
+      hx-get="tasks"
+      hx-target="#list-of-tasks"
+      hx-include="[id='filtering']"
+      hx-trigger="click,keyup[key=='Escape'] from:#task-details-inp"
+    >
+      <kbd class="shortcut_key">Esc</kbd>
+    </button>
+    <button
+      class="btn btn-success btn-xs join-item"
+      id="btn-mark-as-done"
+      hx-post="tasks"
+      hx-target="#list-of-tasks"
+      hx-include="[id='filtering']"
+      {%
+      if
+      task.status
+      !="completed"
+      %}
+      hx-vals='{"status": "completed", "uuid":"{{ task.uuid }}", "action": "StatusUpdate"}'
+      {%
+      else
+      %}
+      hx-vals='{"status": "pending", "uuid":"{{ task.uuid }}", "query": "status:completed", "action": "StatusUpdate" }'
+      {%
+      endif
+      %}
+      hx-trigger="click,keyup[key=='d'] from:#task-details-inp"
+    >
+      <span><span class="shortcut_key">d</span>one</span>
+    </button>
+    <button
+      class="btn btn-accent btn-xs join-item"
+      id="btn-denotate-task"
+      hx-trigger="click,keyup[key=='n'] from:#task-details-inp"
+      hx-on::before-request="window.handleTaskAnnotations(event)"
+      hx-post="tasks"
+      hx-target="#list-of-tasks"
+      hx-include="[id='filtering']"
+      hx-vals='{"uuid":"{{ task.uuid }}", "action": "DenotateTask"}'
+      >
+      <span>de<span class="shortcut_key">n</span>otate</span>
+    </button>
+    <button
+      class="btn btn-info btn-xs join-item"
+      id="btn-timer-toggle"
+      hx-post="tasks"
+      hx-target="#list-of-tasks"
+      hx-include="[id='filtering']"
+      hx-vals='{"uuid":"{{ task.uuid }}", "action": "ToggleTimer", "status": "{% if task.start %}stop{% else %}start{% endif %}"}'
+      hx-trigger="click,keyup[key=='s'] from:#task-details-inp"
+    >
+      <span>
+        {% if task.start %}
+        <span class="shortcut_key">s</span>top {% else %}
+        <span class="shortcut_key">s</span>tart {% endif %}
+      </span>
+    </button>
+    <button
+      class="btn btn-error btn-xs join-item"
+      id="btn-delete-task"
+      hx-get="tasks/{{ task.uuid }}/delete"
+      hx-target="#all-dialog-boxes"
+      hx-include="[id='filtering']"
+      hx-trigger="click,keyup[key=='l'] from:#task-details-inp"
+    >
+      <span>de<span class="shortcut_key">l</span>ete</span>
+    </button>
+    <span class="join-item">
+      <label for="task-details-inp" class="hidden"></label>
+      <input
+        type="text"
+        id="task-details-inp"
+        class="input input-neutral input-xs join-item"
+        placeholder="Cmd Bar, Ctrl+Shift+K"
+        autofocus
+        autocomplete="off"
+    /></span>
+  </div>
+  <table class="table table-xs table-zebra">
+    <tbody>
+      <tr>
+        <th>Description</th>
+        <td class="text-wrap w-2/3">
+            {{ task.description }}
+        </td>
+      </tr>
+      <tr>
+        <th>Uuid</th>
+        <td class="text-wrap w-2/3">
+            {{ task.uuid }}
+        </td>
+      </tr>
+      <tr>
+        <th class="w-1/6">
+          <label for="task-edit-inp">Modify</label>
+        </th>
+        <td>
+          <input
+            type="text"
+            id="task-edit-inp"
+            class="input-neutral input input-xs {% if validation.fields.additional %}border-pink-600 ring-pink-200 input-error{% endif %}"
+            placeholder="Edit task with command"
+            hx-trigger="keyup[key=='Enter'] from:#task-edit-inp"
+            hx-post="tasks/{{ task.uuid }}/details"
+            hx-target="#task-details-modal-box"
+            hx-swap="outerHTML"
+            hx-include="[this],[id='filtering']"
+            name="task_entry"
+            hx-vals='{"uuid":"{{ task.uuid }}", "action": "ModifyTask"}'
+            autocomplete="off"
+            value="{% if task_edit_cmd %}{{ task_edit_cmd }}{% endif %}"
+            title="Modify a task by giving space separated list of options to set. Tags are added by giving +tagname and removed via -tagname. 
+Any arbitary property can be set by giving propertyName:propertyValue. Value as well as both together can be set in quote to incorporate spaces.
+Dates should be given in format yyyy-mm-dd."
+          />
+          {% if validation.fields.additional %}
+          <p class="mt-2 [.validated_&]:peer-[:not(:placeholder-shown)]:peer-invalid:block text-pink-600">
+              {% for a in validation.fields.additional %}
+              {{ a.message }}
+              {% endfor %}
+          </p>
+          {% endif %}
+        </td>
+      </tr>
+      <tr>
+        <th>
+          <label for="task-annot-inp">Annotate</label>
+        </th>
+        <td>
+          <input
+            type="text"
+            id="task-annot-inp"
+            class="input-neutral input input-xs"
+            placeholder="Annotate task"
+            hx-trigger="keyup[key=='Enter'] from:#task-annot-inp"
+            hx-post="tasks"
+            hx-target="#list-of-tasks"
+            hx-include="[this],[id='filtering']"
+            name="task_entry"
+            hx-vals='{"uuid":"{{ task.uuid }}", "action": "AnnotateTask"}'
+          />
+        </td>
+      </tr>
+      <tr>
+        <th>Age</th>
+        <td>
+          {% if task.entry %}{{ date_proper(date=task.entry) }} ({{ date(date=task.entry) }}){% endif %}
+        </td>
+      </tr>
+      <tr>
+        <th>Depends on</th>
+        <td>
+          {% if task.depends %} {% for dep_task in tasks_db %}
+          <button
+            class="btn btn-secondary btn-xs is-a-tag join-item {%if dep_task.status == 'completed'%}btn-outline{% endif %}"
+            hx-trigger="click"
+            hx-get="tasks/{{dep_task.uuid}}/details"
+            hx-target="#task-details-modal-box"
+            hx-swap="outerHTML"
+            title="{{dep_task.description}}"
+          >
+            {% if dep_task.status == 'completed' %}
+            ✓
+            {% endif %}
+            {% if dep_task.id %}
+            {{dep_task.id}}
             {% else %}
-            <span class="shortcut_key">s</span>tart
+            {{dep_task.uuid}}
             {% endif %}
-            </span>
-        </button>
-        <span class="join-item">
-            <label for="task-details-inp" class="hidden"></label>
-            <input type="text" id="task-details-inp"
-                   class="input input-neutral input-xs join-item"
-                   placeholder="Cmd Bar, Ctrl+Shift+K"
-                   autofocus /></span>
-    </div>
-    <table class="table table-xs table-zebra">
-        <tbody>
-        <tr>
-            <th>Description</th>
-            <td class="text-wrap w-2/3">
-                {{ desc::desc(task=task) }}
-            </td>
-        </tr>
-        <tr>
-            <th class="w-1/6">
-                <label for="task-edit-inp">Modify</label>
-            </th>
-            <td>
-                <input type="text" id="task-edit-inp"
-                       class="input-neutral input input-xs"
-                       placeholder="Edit task with command"
-                       hx-trigger="keyup[key=='Enter'] from:#task-edit-inp"
-                       hx-post="tasks"
-                       hx-target="#list-of-tasks"
-                       hx-include="[this],[id='filtering']"
-                       name="task_entry"
-                       hx-vals='{"uuid":"{{ task.uuid }}", "action": "ModifyTask"}'
-                />
-            </td>
-        </tr>
-        <tr>
-            <th>
-                <label for="task-annot-inp">Annotate</label>
-            </th>
-            <td>
-                <input type="text" id="task-annot-inp"
-                       class="input-neutral input input-xs"
-                       placeholder="Annotate task"
-                       hx-trigger="keyup[key=='Enter'] from:#task-annot-inp"
-                       hx-post="tasks"
-                       hx-target="#list-of-tasks"
-                       hx-include="[this],[id='filtering']"
-                       name="task_entry"
-                       hx-vals='{"uuid":"{{ task.uuid }}", "action": "AnnotateTask"}'
-                />
-            </td>
-        </tr>
-        <tr>
-            <th>Age</th>
-            <td>{% if task.entry %}{{ date_proper(date=task.entry) }}{% endif %}</td>
-        </tr>
-        <tr>
-            <th>Depends on</th>
-            <td>
-                {% if task.depends %}
-                {% for uuid in task.depends %}
-                {%if tasks_db[uuid] %}{{ tasks_db[uuid].id }}{% endif %}
-                {% endfor %}
-                {% endif %}
-            </td>
-        </tr>
-        <tr>
-            <th>Project</th>
-            <td>
-                {% if task.project %}
-                <div class="breadcrumbs text-sm">
-                    <ul>
-                    {% for p in task.project | split(pat=".") %}
-                    <li class="">
-                        {{ p }}
-                    </li>
+          </button>
+          {% endfor %} {% endif %}
+        </td>
+      </tr>
+      <tr>
+        <th>Project</th>
+        <td>
+          {% if task.project %}
+          <div class="breadcrumbs text-sm">
+            <ul>
+              {% for p in task.project | split(pat=".") %}
+              <li class="">{{ p }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+          {% endif %}
+        </td>
+      </tr>
+      <tr>
+        <th>Tags</th>
+        <td>
+          <div>
+            {% if task.tags %} {% for p in task.tags %}
+            <span class="badge-sm badge badge-accent"> {{ p }} </span>
+            {% endfor %} {% endif %} {% if task.priority %}
+            <span class="badge badge-sm badge-secondary"
+              >{{ task.priority }}</span
+            >
+            {% endif %}
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <th>Urgency</th>
+        <td>{{ task.urgency }}</td>
+      </tr>
+      <tr>
+        {% if task.start %}
+        <th>Start</th>
+        <td>{{ date_proper(date=task.start) }}</td>
+      </tr>
+      <tr>
+        {% endif %} {% if task.due and task.status != 'completed' %}
+        <th>Due</th>
+        <td>{{ date_proper(date=task.due, in_future=true) }} ({{ date(date=task.due) }})</td>
+        {% endif %}
+      </tr>
+      <tr>
+        {% if task.scheduled %}
+        <th>Scheduled</th>
+        <td>{{ date_proper(date=task.scheduled, in_future=true) }}  ({{ date(date=task.scheduled) }})</td>
+        {% endif%}
+      </tr>
+      <tr>
+        {% if task.wait %}
+        <th>Wait until</th>
+        <td>{{ date_proper(date=task.wait, in_future=true) }}  ({{ date(date=task.wait) }})</td>
+        {% endif%}
+      </tr>
+      <tr>
+        {% if task.end %}
+        <th>End</th>
+        <td>{{ date_proper(date=task.end) }} ({{ date(date=task.end) }})</td>
+        {% endif %}
+      </tr>
+      <tr>
+        {% if task.recur %}
+        <th>RECUR</th>
+        <td>{{task.recur}}</td>
+        {% endif %}
+      </tr>
+      {% if task.annotations %}
+      <tr>
+        <th>Annotations</th>
+        <td><input type="text" id="anno-inp"
+          class="input input-xs input-accent join-item hidden"
+          autocomplete="off"
+          placeholder="Cmd annotation deletion"
+          hx-trigger="changes delay:2s"
+          hx-include="[id='filtering']"
+          hx-target="#task-details-modal-box"
+          hx-swap="outerHTML"
+          autofocus
+          onkeyup="window.handleTaskAnnotationTrigger(event)"
+   /></td>
+      </tr>
+      <tr>
+        <td colspan="2">
+            <table class="class">
+                <tbody>
+                    {% for annotation in task.annotations %}
+                    <tr>
+                        <th>{{date(date=annotation.entry) }}</th>
+                        <td>{{ annotation.description }}</td>
+                        {% if annotate_shortcuts %}
+                        <td>
+                          <button
+                                    id="anno_dlt_{{ annotate_shortcuts[loop.index0] }}"
+                                    class="btn btn-secondary static btn-xs is-a-annotation min-w-12 hidden"
+                                    hx-trigger="click,keyup[key=='{{ annotate_shortcuts[loop.index0] }}'] from:#task-details-inp"
+                                    hx-post="tasks/{{ task.uuid }}/denotate"
+                                    hx-vals='{"entry": "{{ annotation.entry }}", "description": "{{ annotation.description }}"}'
+                                    hx-target="#all-dialog-boxes"
+                            >
+                                <span class="shortcut_key">{{ annotate_shortcuts[loop.index0] }}</span>
+                            </button>
+                        </td>
+                        {% endif %}
+                    </tr>
                     {% endfor %}
-                    </ul>
-                </div>
-                {% endif %}
-            </td>
-        </tr>
-        <tr>
-            <th>Tags</th>
-            <td>
-                <div>
-                    {% if task.tags %}
-                        {% for p in task.tags %}
-                            <span class="badge-sm badge badge-accent">
-                                {{ p }}
-                            </span>
-                        {% endfor %}
-                    {% endif %}
-                    {% if task.priority %}
-                    <span class="badge badge-sm badge-secondary">{{ task.priority }}</span>
-                    {% endif %}
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <th>Urgency</th>
-            <td>{{ task.urgency }}</td>
-        </tr>
-        <tr>
-            {% if task.start %}
-            <th>Start</th>
-            <td>
-                {{ date_proper(date=task.start) }}
-            </td>
-        </tr>
-        <tr>
-            {% endif %}
-            {% if task.due and task.status != 'completed' %}
-            <th>Due</th>
-            <td>
-                {{ date_proper(date=task.due, in_future=true) }}
-            </td>
-            {% endif %}
-        </tr>
-        <tr>
-            {% if task.scheduled %}
-            <th>Schd</th>
-            <td>
-                {{ date_proper(date=task.scheduled, in_future=true) }}
-            </td>
-            {% endif%}
-        </tr>
-        <tr>
-            {% if task.end %}
-            <th>End</th>
-            <td>
-                {{ date_proper(date=task.end) }}
-            </td>
-            {% endif %}
-        </tr>
-        <tr>
-            {% if task.recur %}
-            <th>RECUR</th>
-            <td>
-                {{task.recur}}
-            </td>
-            {% endif %}
-        </tr>
-        </tbody>
-    </table>
-    <script>
-        try {
-            document.getElementById('task-inp').value = '';
-        } catch (e) {
-
-        }
-        document.getElementById('all-dialog-boxes').showModal()
-    </script>
+                </tbody>
+            </table>
+        </td>
+      </tr>
+      {% endif %}
+    </tbody>
+  </table>
+  <script>
+    try {
+      document.getElementById("task-inp").value = "";
+    } catch (e) {}
+    document.getElementById("all-dialog-boxes").showModal();
+  </script>
 </div>

--- a/frontend/templates/tasks.html
+++ b/frontend/templates/tasks.html
@@ -1,20 +1,7 @@
 {% import "desc.html" as desc %}
 {% if has_toast %}
 <div hx-swap-oob="beforeend:#toast">
-    <div class="items-center justify-items-center gap-4 px-5 py-3 text-neutral-300 fixed h-18 top-0 left-0 w-full z-50 bg-cyan-700 shadow-xs shadow-black"
-         hx-trigger="load delay:{{ toast_timeout }}s" hx-get="/msg_clr" id="flash_msg" hx-swap="outerHTML">
-        <div class="flex flex-row">
-            <span class="text-sm font-medium hover:opacity-75 flex-grow">{{ toast_msg }}</span>
-            <span>
-                <button class="rounded bg-white/20 p-1 hover:bg-white/10" hx-get="/msg_clr" hx-target="#toast"
-                        hx-trigger="click,keyup[key=='Escape'] from:#cmd-inp"
-                        autofocus
-                        hx-swap="innerHTML">
-                    <span class="shortcut_key opacity-50">[Esc]</span>
-                </button>
-            </span>
-        </div>
-    </div>
+    {% include 'flash_msg.html' %}
 </div>
 {% endif %}
 <div class="mb-auto h-max">
@@ -73,6 +60,7 @@
                         <label for="tag-inp" class="hidden"></label>
                         <input type="text" id="tag-inp"
                                class="input input-xs input-accent join-item"
+                               autocomplete="off"
                                placeholder="Tag Bar"
                                hx-trigger="changes delay:2s"
                                hx-target="#list-of-tasks"
@@ -113,14 +101,16 @@
             <div class="p-1">
                 {% for task in tasks %}
                 <div class="grid grid-cols-12 gap-2 md:p-2 p-5 rounded-box text-sm even:bg-base-200/40">
-                    <div class="col-span-12 md:col-span-6">
+                    <div class="col-span-12 md:col-span-6"
+                        data-task-status="{{ task.status }}" data-task-uuid="{{ task.uuid }}">
                         <div class="flex gap-2">
                             <div class="w-20 flex-none">
                                 <span class="relative">
                                     <input type="checkbox"
                                            class="checkbox checkbox-sm"
                                            name="checkbox-{{ task.uuid }}"
-                                           id="{{ task_shortcuts[task.uuid] }}"
+                                           autocomplete="off"
+                                   id="{{ task_shortcuts[task.uuid] }}"
                                            hx-trigger="change"
                                            hx-post="tasks" hx-target="#list-of-tasks"
                                            hx-include="[id='filtering']"
@@ -138,7 +128,7 @@
                                         id="{{ task_shortcuts[task.id] }}"
                                         class="btn btn-secondary btn-xs is-a-tag min-w-12 relative"
                                         hx-trigger="click"
-                                        hx-get="task_details?task_id={{ task.uuid }}"
+                                        hx-get="tasks/{{ task.uuid }}/details"
                                         hx-target="#all-dialog-boxes"
                                 >
                                     {{ task.id }}
@@ -193,7 +183,7 @@
                                 {%if tasks_db[uuid] %}
                                 <button class="btn btn-secondary btn-xs is-a-tag join-item"
                                         hx-trigger="click"
-                                        hx-get="task_details?task_id={{ tasks_db[uuid].uuid }}"
+                                        hx-get="tasks/{{ tasks_db[uuid].uuid }}/details"
                                         hx-target="#task_details">
                                     {{ tasks_db[uuid].id }}
                                 </button>

--- a/frontend/templates/undo_report.html
+++ b/frontend/templates/undo_report.html
@@ -61,7 +61,7 @@
 
         <button  class="btn btn-success btn-md"
                 hx-get="tasks"
-                hx-trigger="click,keyup[key=='Escape'] from:all-dialog-boxes"
+                hx-trigger="click,keyup[key=='Escape'] from:body"
                 hx-include="[id='filtering']"
                 hx-target="#list-of-tasks">
             <kbd class="shortcut_key">Esc</kbd> Cancel

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,1 +1,2 @@
 pub mod task;
+pub(crate) mod serde;

--- a/src/backend/serde.rs
+++ b/src/backend/serde.rs
@@ -1,0 +1,128 @@
+
+
+pub(crate) mod task_status_serde {
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(status: &Option<taskchampion::Status>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if let Some(ref d) = *status {
+            let status = match d {
+                taskchampion::Status::Pending => "pending",
+                taskchampion::Status::Completed => "completed",
+                taskchampion::Status::Deleted => "deleted",
+                taskchampion::Status::Recurring => "recurring",
+                taskchampion::Status::Unknown(v) => v.as_ref(),
+            };
+            return s.serialize_str(status);
+        }
+        s.serialize_none()
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<taskchampion::Status>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: Option<String> = Option::deserialize(deserializer)?;
+        if let Some(s) = s {
+            let t = s.to_lowercase();
+            return Ok(Some(match t.as_str() {
+                "pending" => taskchampion::Status::Pending,
+                "completed" => taskchampion::Status::Completed,
+                "deleted" => taskchampion::Status::Deleted,
+                "recurring" => taskchampion::Status::Recurring,
+                &_ => taskchampion::Status::Unknown(t),
+            }));
+        }
+
+        Ok(None)
+    }
+}
+
+pub(crate) mod task_date_format {
+    use chrono::{DateTime, NaiveDateTime, Utc};
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    const FORMAT: &'static str = "%Y%m%dT%H%M%SZ"; // Is always in UTC, not able to parse %:z
+
+    // The signature of a serialize_with function must follow the pattern:
+    //
+    //    fn serialize<S>(&T, S) -> Result<S::Ok, S::Error>
+    //    where
+    //        S: Serializer
+    //
+    // although it may also be generic over the input types T.
+    pub fn serialize<S>(date: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if let Some(dt) = date {
+            let s = format!("{}", dt.format(FORMAT));
+            serializer.serialize_str(&s)
+        } else {
+            serializer.serialize_none()
+        }
+    }
+
+    // The signature of a deserialize_with function must follow the pattern:
+    //
+    //    fn deserialize<'de, D>(D) -> Result<T, D::Error>
+    //    where
+    //        D: Deserializer<'de>
+    //
+    // although it may also be generic over the output types T.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: Option<String> = Option::deserialize(deserializer)?;
+        if let Some(date_str) = s {
+            match NaiveDateTime::parse_from_str(&date_str, FORMAT) {
+                Ok(dt) => Ok(Some(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc))),
+                Err(_) => Ok(None),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+pub(crate) mod task_date_format_mandatory {
+    use chrono::{DateTime, NaiveDateTime, Utc};
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    const FORMAT: &'static str = "%Y%m%dT%H%M%SZ"; // Is always in UTC, not able to parse %:z
+
+    // The signature of a serialize_with function must follow the pattern:
+    //
+    //    fn serialize<S>(&T, S) -> Result<S::Ok, S::Error>
+    //    where
+    //        S: Serializer
+    //
+    // although it may also be generic over the input types T.
+    pub fn serialize<S>(date: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = format!("{}", date.format(FORMAT));
+        serializer.serialize_str(&s)
+    }
+
+    // The signature of a deserialize_with function must follow the pattern:
+    //
+    //    fn deserialize<'de, D>(D) -> Result<T, D::Error>
+    //    where
+    //        D: Deserializer<'de>
+    //
+    // although it may also be generic over the output types T.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let date_str = String::deserialize(deserializer)?;
+        let date_obj = NaiveDateTime::parse_from_str(&date_str, FORMAT)
+            .map_err(serde::de::Error::custom)?;
+        Ok(DateTime::<Utc>::from_naive_utc_and_offset(date_obj, Utc))
+    }
+}

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -66,3 +66,7 @@ impl From<&AppState> for Context {
         ctx
     }
 }
+
+pub fn get_default_context(state: &AppState) -> Context {
+    state.into()
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,2 +1,3 @@
 pub mod errors;
 pub mod app;
+pub mod utils;

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -1,0 +1,23 @@
+use std::collections::HashSet;
+use rand::distr::{Alphanumeric, SampleString};
+
+pub fn make_shortcut(shortcuts: &mut HashSet<String>) -> String {
+    let alpha = Alphanumeric::default();
+    let mut len = 2;
+    let mut tries = 0;
+    loop {
+        let shortcut = alpha.sample_string(&mut rand::rng(), len).to_lowercase();
+        if !shortcuts.contains(&shortcut) {
+            shortcuts.insert(shortcut.clone());
+            return shortcut;
+        }
+        tries += 1;
+        if tries > 1000 {
+            len += 1;
+            if len > 3 {
+                panic!("too many shortcuts! this should not happen");
+            }
+            tries = 0;
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,29 +1,28 @@
-use axum::extract::{Query, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{Html, Response};
 use axum::routing::post;
 use axum::{routing::get, Form, Router};
 use indexmap::IndexMap;
-use rand::distr::{Alphanumeric, SampleString};
-use taskchampion::Uuid;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::string::ToString;
+use taskchampion::Uuid;
 use taskwarrior_web::backend::task::{get_project_list, TaskOperation};
-use taskwarrior_web::core::app::AppState;
+use taskwarrior_web::core::app::{get_default_context, AppState};
 use taskwarrior_web::core::errors::FormValidation;
-use taskwarrior_web::endpoints::tasks::{self, change_task_status};
+use taskwarrior_web::endpoints::tasks::{self, change_task_status, display_task_details};
 use taskwarrior_web::endpoints::tasks::task_query_builder::TaskQuery;
+use taskwarrior_web::endpoints::tasks::{api_denotate_task_entry, display_task_delete, get_task_details, get_task_details_form};
 use taskwarrior_web::endpoints::tasks::{
-    fetch_active_task, get_task_details, list_tasks, run_annotate_command,
-    run_denotate_command, run_modify_command, task_add, task_undo, toggle_task_active, Task,
-    TaskUUID, TaskViewDataRetType,
+    fetch_active_task, list_tasks, run_annotate_command, run_denotate_command,
+    run_modify_command, task_add, task_undo, toggle_task_active, TaskUUID,
+    TaskViewDataRetType,
 };
 use taskwarrior_web::{
-    task_query_merge_previous_params, task_query_previous_params, FlashMsg, NewTask, TWGlobalState,
-    TaskActions, TEMPLATES,
+    task_query_merge_previous_params, task_query_previous_params, FlashMsg, FlashMsgRoles, NewTask, TWGlobalState, TaskActions, TEMPLATES
 };
-use tera::Context;
+use taskwarrior_web::core::utils::make_shortcut;
 use tracing::{error, info, trace};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -55,11 +54,14 @@ async fn main() {
         .route("/tasks/add", get(display_task_add_window))
         .route("/tasks/active", get(get_active_task))
         .route("/tasks/add", post(create_new_task))
+        .route("/tasks/{id}/details", get(display_task_details))
+        .route("/tasks/{id}/details", post(update_task_details))
+        .route("/tasks/{id}/delete", get(display_task_delete))
+        .route("/tasks/{id}/denotate", post(api_denotate_task_entry))
         .route("/msg", get(display_flash_message))
         .route("/msg_clr", get(just_empty))
         .route("/tag_bar", get(get_tag_bar))
         .route("/task_action_bar", get(get_task_action_bar))
-        .route("/task_details", get(display_task_details))
         .route("/bars", get(get_bar))
         .with_state(app_settings);
 
@@ -67,10 +69,6 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
     println!("running on address: {}", addr);
     axum::serve(listener, app).await.unwrap();
-}
-
-fn get_default_context(state: &AppState) -> Context {
-    state.into()
 }
 
 fn init_tracing() {
@@ -81,20 +79,6 @@ fn init_tracing() {
         )
         .with(tracing_subscriber::fmt::layer().with_line_number(true))
         .init();
-}
-
-async fn display_task_details(
-    Query(param): Query<HashMap<String, String>>,
-    app_state: State<AppState>,
-) -> Html<String> {
-    let task_id = param.get("task_id").unwrap().clone();
-    let task = get_task_details(task_id).unwrap();
-    let tq = TaskQuery::new(TWGlobalState::default());
-    let tasks = list_tasks(&tq).unwrap();
-    let mut ctx = get_default_context(&app_state);
-    ctx.insert("tasks_db", &tasks);
-    ctx.insert("task", &task);
-    Html(TEMPLATES.render("task_details.html", &ctx).unwrap())
 }
 
 async fn get_active_task(app_state: State<AppState>) -> Html<String> {
@@ -142,8 +126,9 @@ async fn display_flash_message(
     app_state: State<AppState>,
 ) -> Html<String> {
     let mut ctx = get_default_context(&app_state);
-    ctx.insert("msg", &msg.msg());
-    ctx.insert("timeout", &msg.timeout());
+    ctx.insert("toast_msg", &msg.msg());
+    ctx.insert("toast_timeout", &msg.timeout());
+    ctx.insert("toast_role", "");
     Html(TEMPLATES.render("flash_msg.html", &ctx).unwrap())
 }
 
@@ -153,15 +138,8 @@ async fn get_undo_report(app_state: State<AppState>) -> Html<String> {
             let mut ctx = get_default_context(&app_state);
             let number_operations: i64 = s.values().map(|f| f.len() as i64).sum();
             let heading = format!("The following {} operations would be reverted", number_operations);
-            let undo_report: Vec<(_, &Vec<_>)> = s.iter().map(|(uuid, v)| {
-                let task_description = match get_task_details(uuid.to_string()) {
-                    Ok(t) => format!("{}({})", t.description, uuid),
-                    Err(_) => uuid.to_string(),
-                };
-                (task_description, v)
-            }).collect();
             ctx.insert("heading", &heading);
-            ctx.insert("undo_report", &undo_report);
+            ctx.insert("undo_report", &s);
             Html(TEMPLATES.render("undo_report.html", &ctx).unwrap())
         }
         Err(e) => {
@@ -211,39 +189,18 @@ async fn undo_last_change(
     app_state: State<AppState>,
 ) -> Html<String> {
     task_undo().unwrap();
-    let fm = FlashMsg::new("Undo successful", None);
+    let fm = FlashMsg::new("Undo successful", None, FlashMsgRoles::Success);
     get_tasks_view(task_query_previous_params(&params), Some(fm), &app_state)
 }
 
-fn make_shortcut(shortcuts: &mut HashSet<String>) -> String {
-    let alpha = Alphanumeric::default();
-    let mut len = 2;
-    let mut tries = 0;
-    loop {
-        let shortcut = alpha.sample_string(&mut rand::rng(), len).to_lowercase();
-        if !shortcuts.contains(&shortcut) {
-            shortcuts.insert(shortcut.clone());
-            return shortcut;
-        }
-        tries += 1;
-        if tries > 1000 {
-            len += 1;
-            if len > 3 {
-                panic!("too many shortcuts! this should not happen");
-            }
-            tries = 0;
-        }
-    }
-}
-
 fn get_tasks_view_data(
-    mut tasks: IndexMap<TaskUUID, Task>,
+    mut tasks: IndexMap<TaskUUID, taskwarrior_web::backend::task::Task>,
     filters: &Vec<String>,
 ) -> TaskViewDataRetType {
     let mut tag_map: HashMap<String, String> = HashMap::new();
     let mut task_shortcut_map: HashMap<String, String> = HashMap::new();
     let mut shortcuts = HashSet::new();
-    let task_list: Vec<Task> = tasks
+    let task_list: Vec<taskwarrior_web::backend::task::Task> = tasks
         .values_mut()
         .map(|task| {
             if let Some(tags) = &mut task.tags {
@@ -270,10 +227,14 @@ fn get_tasks_view_data(
                 }
             }
             let shortcut = make_shortcut(&mut shortcuts);
-            task_shortcut_map.insert(task.id.to_string(), shortcut);
+            task_shortcut_map.insert(task.id.unwrap_or(0).to_string(), shortcut);
             let shortcut = make_shortcut(&mut shortcuts);
-            let uuid = task.uuid.clone();
+            let uuid = task.uuid.to_string();
             task_shortcut_map.insert(uuid, shortcut);
+            if task.annotations.is_some() {
+                task.annotations.as_mut().unwrap().sort();
+                task.annotations.as_mut().unwrap().reverse();
+            }
             task.clone()
         })
         .collect();
@@ -308,7 +269,14 @@ fn get_tasks_view_data(
 
 async fn front_page(app_state: State<AppState>) -> Html<String> {
     let tq = TaskQuery::new(TWGlobalState::default());
-    let tasks = list_tasks(&tq).unwrap();
+    let tasks = match list_tasks(&tq) {
+        Ok(e) => e,
+        Err(e) => {
+            error!("Cannot read task list, error: {:?}", e);
+            let x: IndexMap<TaskUUID, taskwarrior_web::backend::task::Task> = IndexMap::new();
+            x
+        },
+    };
     let filters = tq.as_filter_text();
     let TaskViewDataRetType {
         tasks,
@@ -324,7 +292,8 @@ async fn front_page(app_state: State<AppState>) -> Html<String> {
     ctx.insert("filter_value", &serde_json::to_string(&tq).unwrap());
     ctx.insert("tags_map", &tag_map);
     ctx.insert("task_shortcuts", &task_shortcut_map);
-    let t: Option<(&TaskUUID, &Task)> = tasks.iter().find(|(_, task)| task.start.is_some());
+    let t: Option<(&TaskUUID, &taskwarrior_web::backend::task::Task)> =
+        tasks.iter().find(|(_, task)| task.start.is_some());
     if let Some((_, v)) = t {
         ctx.insert("active_task", v);
     }
@@ -386,9 +355,7 @@ fn get_tasks_view_plain(
     ctx_b.insert("tags_map", &tag_map);
     ctx_b.insert("task_shortcuts", &task_shortcut_map);
     if let Some(msg) = flash_msg {
-        ctx_b.insert("has_toast", &true);
-        ctx_b.insert("toast_msg", msg.msg());
-        ctx_b.insert("toast_timeout", &msg.timeout());
+        msg.to_context(&mut ctx_b);
     }
     let t = tasks.iter().find(|(_, task)| task.start.is_some());
     if let Some((_, v)) = t {
@@ -408,7 +375,7 @@ async fn create_new_task(
     };
     match task_add(&new_task, &app_state) {
         Ok(_) => {
-            let flash_msg = FlashMsg::new("New task created", None);
+            let flash_msg = FlashMsg::new("New task created", None, FlashMsgRoles::Success);
             Response::builder()
                 .status(StatusCode::CREATED)
                 .header("HX-Retarget", "#list-of-tasks")
@@ -435,25 +402,26 @@ async fn create_new_task(
 async fn do_task_actions(
     app_state: State<AppState>,
     Form(multipart): Form<TWGlobalState>,
-) -> Html<String> {
+) -> Response<String> {
     info!("{:?}", multipart);
     let fm = match multipart.action().clone().unwrap() {
         TaskActions::StatusUpdate => {
             if let Some(task) = taskwarrior_web::from_task_to_task_update(&multipart) {
                 match change_task_status(task.clone(), &app_state) {
-                    Ok(_) => FlashMsg::new(&format!("Task [{}] was updated", task.uuid), None),
+                    Ok(_) => FlashMsg::new(&format!("Task [{}] was updated", task.uuid), None, FlashMsgRoles::Success),
                     Err(e) => {
                         error!("Failed: {}", e);
-                        FlashMsg::new(&format!("Failed to update task: {e}"), None)
+                        FlashMsg::new(&format!("Failed to update task: {e}"), None, FlashMsgRoles::Error)
                     }
                 }
             } else {
-                FlashMsg::new("No task to update", None)
+                FlashMsg::new("No task to update", None, FlashMsgRoles::Info)
             }
         }
         TaskActions::ToggleTimer => {
             let task_uuid = multipart.uuid().clone().unwrap();
-            match toggle_task_active(task_uuid, &app_state) {
+            let task_status = multipart.status().clone().unwrap_or("start".to_string());
+            match toggle_task_active(task_uuid, task_status, &app_state) {
                 Ok(v) => {
                     if v {
                         FlashMsg::new(
@@ -462,45 +430,82 @@ async fn do_task_actions(
                                 task_uuid
                             ),
                             None,
+                            FlashMsgRoles::Success
                         )
                     } else {
-                        FlashMsg::new(&format!("Task {} stopped", task_uuid), None)
+                        FlashMsg::new(&format!("Task {} stopped", task_uuid), None, FlashMsgRoles::Success)
                     }
                 }
                 Err(e) => {
                     error!("Failed: {}", e);
-                    FlashMsg::new(&format!("Failed to update task: {e}"), None)
+                    FlashMsg::new(&format!("Failed to update task: {e}"), None, FlashMsgRoles::Error)
                 }
             }
         }
         TaskActions::ModifyTask => {
-            let cmd = multipart.task_entry().clone().unwrap();
-            if cmd.is_empty() {
-                error!("Failed: No annotation provided");
-                FlashMsg::new("Failed to execute command, none provided", None)
-            } else {
-                match run_modify_command(multipart.uuid().unwrap(), &cmd) {
-                    Ok(_) => FlashMsg::new("Modify command success", None),
-                    Err(e) => FlashMsg::new(&format!("Modify command failed: {}", e), None),
-                }
-            }
+            error!("Failed: This endpoint is not supported anymore for this task!");
+            FlashMsg::new("Failed to execute command, none provided", None, FlashMsgRoles::Error)
         }
         TaskActions::AnnotateTask => {
             let cmd = multipart.task_entry().clone().unwrap();
             if cmd.is_empty() {
                 error!("Failed: No command provided");
-                FlashMsg::new("Failed to execute command, none provided", None)
+                FlashMsg::new("Failed to execute command, none provided", None, FlashMsgRoles::Error)
             } else {
                 match run_annotate_command(multipart.uuid().unwrap(), &cmd) {
-                    Ok(_) => FlashMsg::new("Annotation added", None),
-                    Err(e) => FlashMsg::new(&format!("Annotation command failed: {}", e), None),
+                    Ok(_) => FlashMsg::new("Annotation added", None, FlashMsgRoles::Success),
+                    Err(e) => FlashMsg::new(&format!("Annotation command failed: {}", e), None, FlashMsgRoles::Error),
                 }
             }
         }
         TaskActions::DenotateTask => match run_denotate_command(multipart.uuid().unwrap()) {
-            Ok(_) => FlashMsg::new("Denotated task", None),
-            Err(e) => FlashMsg::new(&format!("Denotation command failed: {}", e), None),
+            Ok(_) => FlashMsg::new("Denotated task", None, FlashMsgRoles::Success),
+            Err(e) => FlashMsg::new(&format!("Denotation command failed: {}", e), None, FlashMsgRoles::Error),
         },
     };
-    get_tasks_view(task_query_previous_params(&multipart), Some(fm), &app_state)
+    Response::builder()
+        .status(StatusCode::OK)
+        .body(get_tasks_view_plain(task_query_previous_params(&multipart), Some(fm), &app_state))
+        .unwrap()
+}
+
+async fn update_task_details(
+    Path(task_id): Path<Uuid>,
+    app_state: State<AppState>,
+    Form(multipart): Form<TWGlobalState>,
+) -> Response<String> {
+    let cmd = multipart.task_entry().clone().unwrap();
+    match get_task_details(task_id.to_string()) {
+        Ok(mut task) => {
+            match run_modify_command(multipart.uuid().unwrap(), &cmd, &app_state) {
+                Ok(()) => {
+                    let flash_msg = FlashMsg::new("Task updated", None, FlashMsgRoles::Success);
+                    Response::builder()
+                        .status(StatusCode::CREATED)
+                        .header("HX-Retarget", "#list-of-tasks")
+                        .header("HX-Reswap", "innerHTML")
+                        .header("Content-Type", "text/html")
+                        .body(get_tasks_view_plain(task_query_previous_params(&multipart), Some(flash_msg), &app_state))
+                        .unwrap()
+                }
+                Err(e) => {
+                    let tasks_deps = get_task_details_form(&mut task, &app_state);
+                    let mut ctx = get_default_context(&app_state);
+                    ctx.insert("tasks_db", &tasks_deps);
+                    ctx.insert("task", &task);
+                    ctx.insert("validation", &e);
+                    ctx.insert("task_edit_cmd", &cmd);
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .header("Content-Type", "text/html")
+                        .body(TEMPLATES.render("task_details.html", &ctx).unwrap())
+                        .unwrap()
+                }
+            }
+        },
+        Err(_) => Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body("".to_string())
+        .unwrap(),
+    }
 }


### PR DESCRIPTION
This commit brings various optimizations:
 - Annotations are listed descending (the eyes don't need to find the end of the list in order to read the latest update)
 - In detail view, the annotations are separated from the title in order to see meta data still at top. Annotations are listed at end of the popup and are shown descending so the first annotations contains the newest information.
 - Denote offers now the selection of the exact note (earlier it deleted the first one).
 - The "additional attributes" / "modify" failed to proper parse in case of quotation marks (e.g. space were included). This offers now to specify proper description changes.
 - In detail view, a proper deletion prompt is added (with confirmation).
 - Relative times in detail view are shown absolute as well now.
 - Improved alert system in order to proper show as well as considering the alert role (info, warning, error, success).
 - Enforced to disable autocomplete for the cmd bars as it might otherwise happen that the browser is autofilling an already entered command.

Sorry, @tmahmood, its a bit too much for a MR imho, but i was in the flow.
Please carefully read the changes above as they are 'breaking changes'. E.g. the annotations are placed a bit different or sorted differently and i've no configuration foreseen yet.
If you think for some of the points, that we should do some kind of system configurations, please give me the feedback and we can introduce.

Maybe you even want to have a test on it before merging to get a feeling. I've rebased to your current main branch, which contained nice styling updates.
